### PR TITLE
FE-41 Name editor when creating new editor

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -27,6 +27,7 @@ import Resizable from '@/components/Resize/Resizable.vue';
 import { mapGetters } from 'vuex';
 import EditorType from '@/EditorType';
 import { ViewPlugin } from '@baklavajs/plugin-renderer-vue';
+import { Getter } from 'vuex-class';
 
 @Component({
   components: {
@@ -35,26 +36,20 @@ import { ViewPlugin } from '@baklavajs/plugin-renderer-vue';
     Sidebar,
     Canvas,
   },
-  computed: mapGetters([
-    'currEditorType',
-    'currEditorModel',
-    'overviewEditor',
-    'modelEditor',
-    'dataEditor',
-    'trainEditor',
-  ]),
+  computed: mapGetters(['currEditorModel']),
 })
 export default class Editor extends Vue {
   private manager: EditorManager = EditorManager.getInstance();
   private editorWidth = 75; /* percentage */
   private sidebarWidth = 280; /* pixels */
+  @Getter('currEditorType') currEditorType!: EditorType;
 
   private changeWidth(percentage: number) {
     this.editorWidth = percentage;
   }
 
   private currViewPlugin(): ViewPlugin | undefined {
-    switch (this.$store.getters.currEditorType) {
+    switch (this.currEditorType) {
       case EditorType.OVERVIEW:
         return this.manager.overviewCanvas.viewPlugin;
       case EditorType.MODEL:

--- a/src/components/canvas/Canvas.vue
+++ b/src/components/canvas/Canvas.vue
@@ -12,22 +12,21 @@ import {
   Watch,
 } from 'vue-property-decorator';
 import { Engine } from '@baklavajs/plugin-engine';
-import { traverseUiToIr } from '@/app/ir/traversals';
-
 import { ViewPlugin } from '@baklavajs/plugin-renderer-vue';
+import { traverseUiToIr } from '@/app/ir/traversals';
 import { EditorModel } from '@/store/editors/types';
 
 @Component
 export default class Canvas extends Vue {
-    @Prop({ required: true }) readonly viewPlugin!: ViewPlugin;
-    @Prop({ required: true }) readonly editorModel!: EditorModel;
+  @Prop({ required: true }) readonly viewPlugin!: ViewPlugin;
+  @Prop({ required: true }) readonly editorModel!: EditorModel;
 
-    engine = new Engine(true);
+  private engine = new Engine(true);
 
   @Watch('editorModel')
-    onEditorChange(editorModel: EditorModel) {
-      editorModel.editor.use(this.viewPlugin);
-    }
+  onEditorChange(editorModel: EditorModel) {
+    editorModel.editor.use(this.viewPlugin);
+  }
 
   created(): void {
     this.editorModel.editor.use(this.viewPlugin);

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -9,7 +9,7 @@
       </div>
       <VerticalMenuButton
         :label="'+'"
-        :onClick="() => newEditor({ name: 'untitled ' + editors.length, editorType})"
+        :onClick="this.createNewEditor"
         :isSelected="false"
       />
     </div>
@@ -21,6 +21,7 @@ import VerticalMenuButton from '@/components/buttons/VerticalMenuButton.vue';
 import { mapGetters, mapMutations } from 'vuex';
 import { Editor } from '@baklavajs/core';
 import EditorType from '@/EditorType';
+import { Getter, Mutation } from 'vuex-class';
 
 @Component({
   components: { VerticalMenuButton },
@@ -28,14 +29,24 @@ import EditorType from '@/EditorType';
     'currEditorType',
     'currEditorIndex',
   ]),
-  methods: mapMutations([
-    'switchEditor',
-    'newEditor',
-  ]),
+  methods: mapMutations(['switchEditor']),
 })
 export default class NavbarContextualMenu extends Vue {
   @Prop({ required: true }) readonly editors!: Editor[];
   @Prop({ required: true }) readonly editorType!: EditorType
+  @Getter('editorNames') editorNames!: Set<string>;
+  @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string}) => void;
+
+  private createNewEditor(): void {
+    let isNameUnique = false;
+    while (!isNameUnique) {
+      const name = prompt('Please enter a unique name for the editor');
+      if (name !== null && !this.editorNames.has(name)) {
+        isNameUnique = true;
+        this.newEditor({ editorType: this.editorType, name });
+      }
+    }
+  }
 }
 
 </script>

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -6,6 +6,7 @@ import EditorType from '@/EditorType';
 const editorGetters: GetterTree<EditorsState, RootState> = {
   currEditorType: (state) => state.currEditorType,
   currEditorIndex: (state) => state.currEditorIndex,
+  editorNames: (state) => state.editorNames,
   currEditorModel: (state, getters) => {
     const index = getters.currEditorIndex;
     switch (getters.currEditorType) {
@@ -21,11 +22,11 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
         return {};
     }
   },
-  modelEditors: (state: EditorsState) => state.modelEditors,
-  dataEditors: (state: EditorsState) => state.dataEditors,
+  modelEditors: (state) => state.modelEditors,
+  dataEditors: (state) => state.dataEditors,
   trainEditors: (state) => state.trainEditors,
   overviewEditor: (state) => state.overviewEditor,
-  modelEditor: (state: EditorsState) => (index: number) => state.modelEditors[index],
+  modelEditor: (state) => (index: number) => state.modelEditors[index],
   dataEditor: (state) => (index: number) => state.dataEditors[index],
   trainEditor: (state) => (index: number) => state.trainEditors[index],
 };

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -21,11 +21,11 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
         return {};
     }
   },
-  modelEditors: (state) => state.modelEditors,
-  dataEditors: (state) => state.dataEditors,
+  modelEditors: (state: EditorsState) => state.modelEditors,
+  dataEditors: (state: EditorsState) => state.dataEditors,
   trainEditors: (state) => state.trainEditors,
   overviewEditor: (state) => state.overviewEditor,
-  modelEditor: (state) => (index: number) => state.modelEditors[index],
+  modelEditor: (state: EditorsState) => (index: number) => state.modelEditors[index],
   dataEditor: (state) => (index: number) => state.dataEditors[index],
   trainEditor: (state) => (index: number) => state.trainEditors[index],
 };

--- a/src/store/editors/index.ts
+++ b/src/store/editors/index.ts
@@ -9,13 +9,14 @@ import { EditorsState } from './types';
 export const editorState: EditorsState = {
   currEditorType: EditorType.MODEL,
   currEditorIndex: 0,
+  editorNames: new Set<string>(['untitled']),
   overviewEditor: {
     name: 'Overview',
     editor: newEditor(EditorType.OVERVIEW), // TODO: Lazy create?
   },
   modelEditors: [
     {
-      name: 'untitled 0',
+      name: 'untitled',
       editor: newEditor(EditorType.MODEL),
     },
   ],

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -15,14 +15,17 @@ const editorMutations: MutationTree<EditorsState> = {
     switch (editorType) {
       case EditorType.MODEL:
         state.currEditorType = editorType;
+        state.editorNames.add(name);
         state.currEditorIndex = state.modelEditors.push({ name, editor }) - 1;
         break;
       case EditorType.DATA:
         state.currEditorType = editorType;
+        state.editorNames.add(name);
         state.currEditorIndex = state.dataEditors.push({ name, editor }) - 1;
         break;
       case EditorType.TRAIN:
         state.currEditorType = editorType;
+        state.editorNames.add(name);
         state.currEditorIndex = state.trainEditors.push({ name, editor }) - 1;
         break;
       default:

--- a/src/store/editors/types.ts
+++ b/src/store/editors/types.ts
@@ -9,6 +9,7 @@ export interface EditorModel {
 export interface EditorsState {
   currEditorType: EditorType;
   currEditorIndex: number;
+  editorNames: Set<string>;
   overviewEditor: EditorModel;
   modelEditors: EditorModel[];
   dataEditors: EditorModel[];

--- a/tests/unit/store/editors/getters.spec.ts
+++ b/tests/unit/store/editors/getters.spec.ts
@@ -1,0 +1,83 @@
+import editorGetters from '@/store/editors/getters';
+import { EditorsState } from '@/store/editors/types';
+import { RootState } from '@/store/types';
+import { mockEditorState, mockModelEditors } from './mockData';
+
+function getCurrEditorType(state: Partial<EditorsState>) {
+  return editorGetters.currEditorType(
+    state as EditorsState,
+    undefined,
+    {} as RootState,
+    undefined,
+  );
+}
+
+function getCurrEditorIndex(state: Partial<EditorsState>) {
+  return editorGetters.currEditorIndex(
+    state as EditorsState,
+    undefined,
+    {} as RootState,
+    undefined,
+  );
+}
+
+function getCurrEditorModel(state: Partial<EditorsState>) {
+  const currEditorType = getCurrEditorType(state);
+  const currEditorIndex = getCurrEditorIndex(state);
+  return editorGetters.currEditorModel(
+    state as EditorsState,
+    { currEditorType, currEditorIndex },
+    {} as RootState,
+    undefined,
+  );
+}
+
+describe('editorGetters', () => {
+  describe('currEditorModel', () => {
+    test('returns empty object when unknown currEditorType', () => {
+      const state: Partial<EditorsState> = {
+        currEditorIndex: 1,
+        currEditorType: 1000,
+      };
+
+      const currEditorModel = getCurrEditorModel(state);
+
+      expect(currEditorModel).toEqual({});
+    });
+
+    test('returns currEditorModel using current index and type', () => {
+      const currEditorModel = getCurrEditorModel(mockEditorState);
+
+      expect(currEditorModel).toBe(mockModelEditors[2]);
+    });
+  });
+
+  describe('modelEditor', () => {
+    test('returns undefined when index is out of bounds', () => {
+      const state: Partial<EditorsState> = {
+        modelEditors: [],
+      };
+      const modelEditorGetter = editorGetters.modelEditor(
+        state as EditorsState,
+        undefined,
+        {} as RootState,
+        undefined,
+      );
+
+      expect(modelEditorGetter(-1)).toBeUndefined();
+      expect(modelEditorGetter(1)).toBeUndefined();
+    });
+
+    test('returns modelEditor of given index', () => {
+      const index = 1;
+
+      const editor = editorGetters.modelEditor(
+        mockEditorState,
+        undefined,
+        {} as RootState,
+        undefined,
+      )(index);
+      expect(editor).toBe(mockEditorState.modelEditors[index]);
+    });
+  });
+});

--- a/tests/unit/store/editors/mockData.ts
+++ b/tests/unit/store/editors/mockData.ts
@@ -1,0 +1,32 @@
+import { EditorModel, EditorsState } from '@/store/editors/types';
+import newEditor from '@/baklava/Utils';
+import EditorType from '@/EditorType';
+
+export const mockOverviewEditor: EditorModel = {
+  name: 'Overview',
+  editor: newEditor(EditorType.OVERVIEW),
+};
+
+export const mockModelEditors: EditorModel[] = [
+  {
+    name: 'name0',
+    editor: newEditor(EditorType.MODEL),
+  },
+  {
+    name: 'name1',
+    editor: newEditor(EditorType.MODEL),
+  },
+  {
+    name: 'name2',
+    editor: newEditor(EditorType.MODEL),
+  },
+];
+
+export const mockEditorState: EditorsState = {
+  currEditorType: EditorType.MODEL,
+  currEditorIndex: 2,
+  overviewEditor: mockOverviewEditor,
+  modelEditors: mockModelEditors,
+  dataEditors: [],
+  trainEditors: [],
+};

--- a/tests/unit/store/editors/mockData.ts
+++ b/tests/unit/store/editors/mockData.ts
@@ -25,6 +25,7 @@ export const mockModelEditors: EditorModel[] = [
 export const mockEditorState: EditorsState = {
   currEditorType: EditorType.MODEL,
   currEditorIndex: 2,
+  editorNames: new Set<string>(['name0', 'name1', 'name2']),
   overviewEditor: mockOverviewEditor,
   modelEditors: mockModelEditors,
   dataEditors: [],

--- a/tests/unit/store/editors/mutations.spec.ts
+++ b/tests/unit/store/editors/mutations.spec.ts
@@ -1,0 +1,49 @@
+import editorMutations from '@/store/editors/mutations';
+import EditorType from '@/EditorType';
+import { mockEditorState } from './mockData';
+
+describe('editorMutations', () => {
+  describe('switchEditor', () => {
+    test('sets editorType and index', () => {
+      const editorType: EditorType = EditorType.DATA;
+      const index = 7;
+      const payload = { editorType, index };
+      editorMutations.switchEditor(mockEditorState, payload);
+
+      expect(mockEditorState).toMatchObject({
+        currEditorType: editorType,
+        currEditorIndex: index,
+      });
+    });
+  });
+
+  describe('newEditor', () => {
+    test('does not change current editor if unknown editorType', () => {
+      const editorType: EditorType = 1000;
+      const index = 4;
+      const payload = { editorType, index };
+      editorMutations.newEditor(mockEditorState, payload);
+
+      expect(mockEditorState.currEditorType).not.toEqual(editorType);
+      expect(mockEditorState.currEditorIndex).not.toEqual(index);
+    });
+
+    test('creates new editor and sets it to be current', () => {
+      const editorType: EditorType = EditorType.TRAIN;
+      const name = 'mockName';
+      const payload = { editorType, name };
+
+      const currNumTrainEditors = mockEditorState.trainEditors.length;
+      editorMutations.newEditor(mockEditorState, payload);
+      const newNumTrainEditors = mockEditorState.trainEditors.length;
+
+      expect(newNumTrainEditors - currNumTrainEditors).toEqual(1);
+
+      expect(mockEditorState.editorNames.has(name)).toBe(true);
+      expect(mockEditorState).toMatchObject({
+        currEditorType: editorType,
+        currEditorIndex: newNumTrainEditors - 1,
+      });
+    });
+  });
+});


### PR DESCRIPTION
Uses prompt for now until modal is implemented - name has to be globallly unique. 

I spent a long time trying to get a `Map` to work but they aren't well supported in VueJS eg was not re-rendering when new entry was added to map and v-for loop is not compatible with map. Therefore I decided to just store a set of names to ensure uniqueness and kept with the current implementation of creating and switching editors.

Also added tests for getters + mutations.