### PR TITLE
FE-45 FE-47 Save and load workspace

### DIFF
--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -106,7 +106,7 @@
 import { Component } from 'vue-property-decorator';
 import { Components } from '@baklavajs/plugin-renderer-vue';
 import ArrowButton from '@/inputs/ArrowButton.vue';
-import { Layers } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 @Component({
   components: { ArrowButton },
@@ -120,16 +120,20 @@ export default class CustomNode extends Components.Node {
 
   get titleBackground() {
     switch (this.data.type) {
-      case Layers.Linear:
+      case Nodes.Dense:
         return { background: 'var(--black)' };
-      case Layers.Conv:
+      case Nodes.Conv1D:
+      case Nodes.Conv2D:
+      case Nodes.Conv3D:
         return { background: 'var(--blue)' };
-      case Layers.Pool:
+      case Nodes.MaxPool2D:
         return { background: 'var(--red)' };
-      case Layers.Regularization:
+      case Nodes.Dropout:
         return { background: 'var(--pink)' };
-      case Layers.Reshape:
+      case Nodes.Flatten:
         return { background: 'var(--green)' };
+      case Nodes.Custom:
+        return { background: 'var(--purple)' };
       default:
         return { background: 'var(--black)' };
     }

--- a/src/file/EditorAsJson.ts
+++ b/src/file/EditorAsJson.ts
@@ -1,0 +1,50 @@
+import { EditorModel } from '@/store/editors/types';
+import EditorType from '@/EditorType';
+import newEditor from '@/baklava/Utils';
+import { Editor } from '@baklavajs/core';
+import EditorManager from '@/EditorManager';
+
+export const FILENAME = 'ivann';
+
+export function saveEditor(editor: EditorModel) {
+  return {
+    name: editor.name,
+    editorState: editor.editor.save(),
+  };
+}
+
+export function saveEditors(editors: EditorModel[]) {
+  const editorsSaved = [];
+  for (const editor of editors) {
+    editorsSaved.push(saveEditor(editor));
+  }
+
+  return editorsSaved;
+}
+
+export function loadEditor(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editorType: EditorType, editorSaved: any, names: Set<string>,
+): EditorModel {
+  const { name, editorState } = editorSaved;
+
+  names.add(name);
+
+  const editor: Editor = newEditor(editorType);
+  editor.use(EditorManager.getInstance().viewPlugin);
+  editor.load(editorState);
+
+  return { name, editor };
+}
+
+export function loadEditors(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  editorType: EditorType, editorsSaved: any, names: Set<string>,
+): EditorModel[] {
+  const editorsLoaded = [];
+  for (const editorSaved of editorsSaved) {
+    editorsLoaded.push(loadEditor(editorType, editorSaved, names));
+  }
+
+  return editorsLoaded;
+}

--- a/src/file/Utils.ts
+++ b/src/file/Utils.ts
@@ -1,0 +1,7 @@
+export function download(label: string, content: string) {
+  const blob = new Blob([content], { type: 'application/json' });
+  const a = document.createElement('a');
+  a.href = window.URL.createObjectURL(blob);
+  a.download = label;
+  a.click();
+}

--- a/src/nodes/model/conv/Conv1D.ts
+++ b/src/nodes/model/conv/Conv1D.ts
@@ -1,8 +1,8 @@
 import Conv, { ConvOptions } from '@/nodes/model/conv/Conv';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 export default class Conv1D extends Conv {
-  type = Layers.Conv;
+  type = Nodes.Conv1D;
   name = Nodes.Conv1D;
 
   protected addKernelStride(): void {

--- a/src/nodes/model/conv/Conv2D.ts
+++ b/src/nodes/model/conv/Conv2D.ts
@@ -1,8 +1,8 @@
 import Conv, { ConvOptions } from '@/nodes/model/conv/Conv';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 export default class Conv2D extends Conv {
-  type = Layers.Conv;
+  type = Nodes.Conv2D;
   name = Nodes.Conv2D;
 
   protected addKernelStride(): void {

--- a/src/nodes/model/conv/Conv3D.ts
+++ b/src/nodes/model/conv/Conv3D.ts
@@ -1,8 +1,8 @@
 import Conv, { ConvOptions } from '@/nodes/model/conv/Conv';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 export default class Conv3D extends Conv {
-  type = Layers.Conv;
+  type = Nodes.Conv3D;
   name = Nodes.Conv3D;
 
   protected addKernelStride(): void {

--- a/src/nodes/model/custom/Custom.ts
+++ b/src/nodes/model/custom/Custom.ts
@@ -1,12 +1,12 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 import parse from '@/app/parser/parser';
 
 export enum CustomOptions{
   InlineCode = 'Inline Code',
 }
 export default class Custom extends Node {
-  type = Layers.Custom;
+  type = Nodes.Custom;
   name = Nodes.Custom;
 
   private inputNames: string[] = [];

--- a/src/nodes/model/linear/Dense.ts
+++ b/src/nodes/model/linear/Dense.ts
@@ -1,11 +1,11 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 import { valuesOf } from '@/app/util';
 import { BuiltinActivationF, BuiltinInitializer, BuiltinRegularizer } from '@/app/ir/irCommon';
 import CheckboxValue from '@/baklava/CheckboxValue';
 
 export default class Dense extends Node {
-  type = Layers.Linear;
+  type = Nodes.Dense;
   name = Nodes.Dense;
 
   constructor() {

--- a/src/nodes/model/pool/MaxPool2D.ts
+++ b/src/nodes/model/pool/MaxPool2D.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 import { valuesOf } from '@/app/util';
 import { Padding } from '@/app/ir/irCommon';
 import { ConvOptions } from '@/nodes/model/conv/Conv';
@@ -10,7 +10,7 @@ export enum MaxPool2DOptions{
   Padding = 'Padding'
 }
 export default class MaxPool2D extends Node {
-  type = Layers.Pool;
+  type = Nodes.MaxPool2D;
   name = Nodes.MaxPool2D;
 
   constructor() {

--- a/src/nodes/model/regularization/Dropout.ts
+++ b/src/nodes/model/regularization/Dropout.ts
@@ -1,8 +1,8 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 export default class Dropout extends Node {
-  type = Layers.Regularization
+  type = Nodes.Dropout;
   name = Nodes.Dropout;
 
   constructor() {

--- a/src/nodes/model/reshape/Flatten.ts
+++ b/src/nodes/model/reshape/Flatten.ts
@@ -1,8 +1,8 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { Nodes } from '@/nodes/model/Types';
 
 export default class Flatten extends Node {
-  type = Layers.Reshape;
+  type = Nodes.Flatten;
   name = Nodes.Flatten;
 
   constructor() {

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -7,6 +7,12 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
   currEditorType: (state) => state.currEditorType,
   currEditorIndex: (state) => state.currEditorIndex,
   editorNames: (state) => state.editorNames,
+  allEditorModels: (state) => ({
+    overviewEditor: state.overviewEditor,
+    modelEditors: state.modelEditors,
+    dataEditors: state.dataEditors,
+    trainEditors: state.trainEditors,
+  }),
   currEditorModel: (state, getters) => {
     const index = getters.currEditorIndex;
     switch (getters.currEditorType) {

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -4,6 +4,7 @@ import { Editor } from '@baklavajs/core';
 import newEditor from '@/baklava/Utils';
 import EditorType from '@/EditorType';
 import EditorManager from '@/EditorManager';
+import { loadEditor, loadEditors } from '@/file/EditorAsJson';
 
 const editorMutations: MutationTree<EditorsState> = {
   switchEditor(state, { editorType, index }) {
@@ -33,6 +34,22 @@ const editorMutations: MutationTree<EditorsState> = {
       default:
         break;
     }
+  },
+  loadEditors(state, file) {
+    const editorNames: Set<string> = new Set<string>();
+
+    state.overviewEditor = loadEditor(EditorType.OVERVIEW, file.overviewEditor, editorNames);
+    state.modelEditors = loadEditors(EditorType.MODEL, file.modelEditors, editorNames);
+    state.dataEditors = loadEditors(EditorType.DATA, file.dataEditors, editorNames);
+    state.trainEditors = loadEditors(EditorType.TRAIN, file.trainEditors, editorNames);
+
+    state.editorNames = editorNames;
+
+    state.currEditorType = EditorType.MODEL;
+    state.currEditorIndex = 0;
+
+    // TODO: Remove this hack - causes <baklava-editor> to re-render
+    state.modelEditors[0].name += ' ';
   },
 };
 

--- a/src/store/editors/types.ts
+++ b/src/store/editors/types.ts
@@ -6,12 +6,15 @@ export interface EditorModel {
   editor: Editor;
 }
 
-export interface EditorsState {
-  currEditorType: EditorType;
-  currEditorIndex: number;
-  editorNames: Set<string>;
+export interface EditorModels {
   overviewEditor: EditorModel;
   modelEditors: EditorModel[];
   dataEditors: EditorModel[];
   trainEditors: EditorModel[];
+}
+
+export interface EditorsState extends EditorModels {
+  currEditorType: EditorType;
+  currEditorIndex: number;
+  editorNames: Set<string>;
 }


### PR DESCRIPTION
Can save all editors incl. the data inside them to a JSON and can load from JSON file as well.

A re-render is not triggered unless the key of `<baklava-editor>` changes which is the name of the current editor. This is an issue when you are on an editor with the same name as the one you are loaded into it. Currently I have a hacky fix which adds a whitespace at the end but I will experiment with creating UUIDs for editors.