### PR TITLE
FE-54 Implement Auto-Saving and Auto-Loading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15410,6 +15410,11 @@
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
       "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w=="
     },
+    "vue-cookies": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/vue-cookies/-/vue-cookies-1.7.4.tgz",
+      "integrity": "sha512-mOS5Btr8V9zvAtkmQ7/TfqJIropOx7etDAgBywPCmHjvfJl2gFbH2XgoMghleLoyyMTi5eaJss0mPN7arMoslA=="
+    },
     "vue-eslint-parser": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "stack-typescript": "^1.0.4",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
+    "vue-cookies": "^1.7.4",
     "vue-property-decorator": "^8.4.2",
     "vue-router": "^3.2.0",
     "vuelidate": "^0.7.5",

--- a/src/components/Titlebar.vue
+++ b/src/components/Titlebar.vue
@@ -44,6 +44,7 @@ import { FILENAME, saveEditor, saveEditors } from '@/file/EditorAsJson';
 export default class Titlebar extends Vue {
   @Getter('allEditorModels') editorModels!: EditorModels;
   @Mutation('loadEditors') loadEditors!: (file: any) => void;
+  @Mutation('resetState') resetState!: () => void;
 
   private share() {
     console.log(`Share button pressed. ${this.$data}`);
@@ -93,30 +94,7 @@ export default class Titlebar extends Vue {
     // TODO FE-55 Implement better Confirm dialog
     if (window.confirm('Are you sure you want to create a new project? '
       + 'All unsaved progress will be lost.')) {
-      const blankProject = {
-        overviewEditor: {
-          name: 'Overview',
-          editorState: {
-            nodes: [],
-            connections: [],
-          },
-        },
-        modelEditors: [{
-          name: 'untitled',
-          editorState: {
-            nodes: [],
-            connections: [],
-            panning: {
-              x: 0,
-              y: 0,
-            },
-            scaling: 1,
-          },
-        }],
-        dataEditors: [],
-        trainEditors: [],
-      };
-      this.loadEditors(blankProject);
+      this.resetState();
       this.$cookies.remove('unsaved');
     }
   }

--- a/src/components/Titlebar.vue
+++ b/src/components/Titlebar.vue
@@ -25,6 +25,9 @@
       <span class="icon-button" @click="save">
         <i class="titlebar-icon fas fa-save fa-lg mx-2"/>
       </span>
+      <span class="icon-button" @click="newProject">
+        <i class="titlebar-icon fas fa-file fa-lg mx-2"/>
+      </span>
     </div>
   </div>
 </template>
@@ -40,7 +43,7 @@ import { FILENAME, saveEditor, saveEditors } from '@/file/EditorAsJson';
 @Component
 export default class Titlebar extends Vue {
   @Getter('allEditorModels') editorModels!: EditorModels;
-  @Mutation('loadEditors') loadEditors!: (editorModels: EditorModels) => void;
+  @Mutation('loadEditors') loadEditors!: (file: any) => void;
 
   private share() {
     console.log(`Share button pressed. ${this.$data}`);
@@ -84,6 +87,38 @@ export default class Titlebar extends Vue {
     };
 
     download(FILENAME, JSON.stringify(editorsSaved));
+  }
+
+  private newProject() {
+    // TODO FE-55 Implement better Confirm dialog
+    if (window.confirm('Are you sure you want to create a new project? '
+      + 'All unsaved progress will be lost.')) {
+      const blankProject = {
+        overviewEditor: {
+          name: 'Overview',
+          editorState: {
+            nodes: [],
+            connections: [],
+          },
+        },
+        modelEditors: [{
+          name: 'untitled',
+          editorState: {
+            nodes: [],
+            connections: [],
+            panning: {
+              x: 0,
+              y: 0,
+            },
+            scaling: 1,
+          },
+        }],
+        dataEditors: [],
+        trainEditors: [],
+      };
+      this.loadEditors(blankProject);
+      this.$cookies.remove('unsaved');
+    }
   }
 }
 </script>

--- a/src/components/canvas/Canvas.vue
+++ b/src/components/canvas/Canvas.vue
@@ -11,13 +11,16 @@ import {
   Vue,
   Watch,
 } from 'vue-property-decorator';
+import { Getter } from 'vuex-class';
 import { Engine } from '@baklavajs/plugin-engine';
 import { ViewPlugin } from '@baklavajs/plugin-renderer-vue';
-import { EditorModel } from '@/store/editors/types';
+import { EditorModel, EditorModels } from '@/store/editors/types';
 import istateToGraph from '@/app/ir/istateToGraph';
+import { saveEditor, saveEditors } from '@/file/EditorAsJson';
 
 @Component
 export default class Canvas extends Vue {
+  @Getter('allEditorModels') editorModels!: EditorModels;
   @Prop({ required: true }) readonly viewPlugin!: ViewPlugin;
   @Prop({ required: true }) readonly editorModel!: EditorModel;
 
@@ -26,6 +29,7 @@ export default class Canvas extends Vue {
   @Watch('editorModel')
   onEditorChange(editorModel: EditorModel) {
     editorModel.editor.use(this.viewPlugin);
+    editorModel.editor.use(this.engine);
   }
 
   created(): void {
@@ -34,6 +38,24 @@ export default class Canvas extends Vue {
 
     this.engine.events.calculated.addListener(this, () => {
       console.log('Something changed!');
+
+      // Auto-Saving
+      const {
+        overviewEditor,
+        modelEditors,
+        dataEditors,
+        trainEditors,
+      } = this.editorModels;
+
+      const editorsSaved = {
+        overviewEditor: saveEditor(overviewEditor),
+        modelEditors: saveEditors(modelEditors),
+        dataEditors: saveEditors(dataEditors),
+        trainEditors: saveEditors(trainEditors),
+      };
+      this.$cookies.set('unsaved', editorsSaved);
+
+      // Building IR
       const state = this.editorModel.editor.save();
       istateToGraph(state);
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,9 @@
 import { BaklavaVuePlugin } from '@baklavajs/plugin-renderer-vue';
 import '@baklavajs/plugin-renderer-vue/dist/styles.css';
 
+// Import Vue-Cookies
+import VueCookies from 'vue-cookies';
+
 // Import fontawesome
 import '@fortawesome/fontawesome-free/css/all.css'; // Fontawesome
 import '@fortawesome/fontawesome-free/js/all';
@@ -14,6 +17,7 @@ import router from './router';
 import store from './store';
 
 Vue.use(BaklavaVuePlugin);
+Vue.use(VueCookies);
 Vue.config.productionTip = false;
 
 new Vue({

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -50,6 +50,25 @@ const editorMutations: MutationTree<EditorsState> = {
     state.currEditorType = EditorType.MODEL;
     state.currEditorIndex = 0;
   },
+  resetState(state) {
+    state.overviewEditor = {
+      id: randomUuid(),
+      name: 'Overview',
+      editor: newEditor(EditorType.OVERVIEW),
+    };
+    state.modelEditors = [{
+      id: randomUuid(),
+      name: 'untitled',
+      editor: newEditor(EditorType.MODEL),
+    }];
+    state.dataEditors = [];
+    state.trainEditors = [];
+
+    state.editorNames = new Set<string>(['untitled']);
+
+    state.currEditorType = EditorType.MODEL;
+    state.currEditorIndex = 0;
+  },
 };
 
 export default editorMutations;

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -12,11 +12,12 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import Navbar from '@/components/navbar/Navbar.vue';
 import Editor from '@/components/Editor.vue';
 import Titlebar from '@/components/Titlebar.vue';
+import { Mutation } from 'vuex-class';
 
 @Component({
   components: {
@@ -26,6 +27,13 @@ import Titlebar from '@/components/Titlebar.vue';
   },
 })
 export default class Home extends Vue {
+  @Mutation('loadEditors') loadEditors!: (file: any) => void;
+
+  created() {
+    if (this.$cookies.isKey('unsaved')) {
+      this.loadEditors(this.$cookies.get('unsaved'));
+    }
+  }
 }
 </script>
 

--- a/tests/unit/store/editors/mutations.spec.ts
+++ b/tests/unit/store/editors/mutations.spec.ts
@@ -1,5 +1,6 @@
 import editorMutations from '@/store/editors/mutations';
 import EditorType from '@/EditorType';
+import { editorState } from '@/store/editors';
 import { mockEditorState } from './mockData';
 
 describe('editorMutations', () => {


### PR DESCRIPTION
This PR implements Auto-Saving and Auto-Loading using cookies.

For now we use the "calculated" event to save any changes, so that changing positions only without changing parameters won't trigger save. Do we want to fix this?

A next step is to add a Cookie Law popup (maybe use [vue-cookie-law](https://www.npmjs.com/package/vue-cookie-law)?)