### PR TITLE
FE-56 Allow partial Auto-Saving (also adds Cookie Law banner)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14726,6 +14726,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tiny-cookie/-/tiny-cookie-2.3.2.tgz",
+      "integrity": "sha512-qbymkVh+6+Gc/c9sqnvbG+dOHH6bschjphK3SHgIfT6h/t+63GBL37JXNoXEc6u/+BcwU6XmaWUuf19ouLVtPg=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -15418,6 +15423,14 @@
       "version": "7.2.6",
       "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.6.tgz",
       "integrity": "sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w=="
+    },
+    "vue-cookie-law-with-type": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vue-cookie-law-with-type/-/vue-cookie-law-with-type-2.1.1.tgz",
+      "integrity": "sha512-2h86Pt1M9nsQmbSNAODxpL2P+hExft1GoijbJfSnhP18goOlTIEasaO54hN+aeCtMSHWNFqZME0QquCkM9ltfw==",
+      "requires": {
+        "tiny-cookie": "^2.1.1"
+      }
     },
     "vue-cookies": {
       "version": "1.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,102 +2216,6 @@
         "tslint": "^5.20.1",
         "webpack": "^4.0.0",
         "yorkie": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
-          }
-        },
-        "semver": {
-          "version": "7.3.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-          "dev": true,
-          "optional": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "@vue/cli-plugin-unit-jest": {
@@ -7560,6 +7464,102 @@
         "worker-rpc": "^0.1.0"
       }
     },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
@@ -9907,14 +9907,23 @@
       }
     },
     "jsonfile": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
-      "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "optional": true,
       "requires": {
         "graceful-fs": "^4.1.6",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true,
+          "optional": true
+        }
       }
     },
     "jsprim": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "stack-typescript": "^1.0.4",
     "vue": "^2.6.11",
     "vue-class-component": "^7.2.3",
+    "vue-cookie-law-with-type": "^2.1.1",
     "vue-cookies": "^1.7.4",
     "vue-property-decorator": "^8.4.2",
     "vue-router": "^3.2.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,19 @@
 <template>
   <div id="app">
     <router-view/>
+    <cookie-law theme="dark-lime"></cookie-law>
   </div>
 </template>
 
 <script>
-import { Vue } from 'vue-property-decorator';
+import CookieLaw from 'vue-cookie-law-with-type';
+import { Component, Vue } from 'vue-property-decorator';
 
+@Component({
+  components: {
+    CookieLaw,
+  },
+})
 export default class App extends Vue {
 }
 </script>
@@ -18,5 +25,17 @@ export default class App extends Vue {
 }
 #nav a.router-link-exact-active {
   color: #42b983;
+}
+
+.Cookie {
+  background: var(--grey) !important;
+  padding-top: 0.5em !important;
+  padding-bottom: 0.5em !important;
+}
+
+.Cookie__button {
+  background: var(--blue) !important;
+  padding-top: 0.2em !important;
+  padding-bottom: 0.2em !important;
 }
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,19 +23,26 @@ export default class App extends Vue {
   font-weight: bold;
   color: #2c3e50;
 }
+
 #nav a.router-link-exact-active {
   color: #42b983;
 }
 
 .Cookie {
-  background: var(--grey) !important;
+  background: var(--background) !important;
   padding-top: 0.5em !important;
   padding-bottom: 0.5em !important;
+  border-top: var(--grey) 1px solid;
 }
 
 .Cookie__button {
   background: var(--blue) !important;
-  padding-top: 0.2em !important;
-  padding-bottom: 0.2em !important;
+  border-radius: 4px !important;
+  padding: 0.5em 3em !important;
+  white-space: nowrap;
+}
+
+.Cookie__button:hover {
+  background: #1B67E0 !important;
 }
 </style>

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -23,6 +23,7 @@ import EditorType from '@/EditorType';
 import { Getter, Mutation } from 'vuex-class';
 import { EditorModel } from '@/store/editors/types';
 import { uniqueTextInput } from '@/inputs/prompt';
+import { saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 
 @Component({
   components: { VerticalMenuButton },
@@ -36,6 +37,8 @@ export default class NavbarContextualMenu extends Vue {
   @Prop({ required: true }) readonly editors!: EditorModel[];
   @Prop({ required: true }) readonly editorType!: EditorType;
   @Getter('editorNames') editorNames!: Set<string>;
+  @Getter('saveWithNames') saveWithNames!: SaveWithNames;
+  @Getter('currEditorModel') currEditorModel!: EditorModel;
   @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string}) => void;
 
   private createNewEditor(): void {
@@ -43,6 +46,9 @@ export default class NavbarContextualMenu extends Vue {
       'Please enter a unique name for the editor');
     if (name !== null) {
       this.newEditor({ editorType: this.editorType, name });
+      // Auto-Saving this new Editor
+      this.$cookies.set('unsaved-project', this.saveWithNames);
+      this.$cookies.set(`unsaved-editor-${name}`, saveEditor(this.currEditorModel));
     }
   }
 }

--- a/src/file/EditorAsJson.ts
+++ b/src/file/EditorAsJson.ts
@@ -1,16 +1,18 @@
+/* eslint-disable max-classes-per-file */
 import { EditorModel } from '@/store/editors/types';
 import EditorType from '@/EditorType';
 import newEditor from '@/baklava/Utils';
 import { Editor } from '@baklavajs/core';
 import EditorManager from '@/EditorManager';
 import { randomUuid, UUID } from '@/app/util';
+import { IState } from '@baklavajs/core/dist/baklavajs-core/types/state.d';
 
 export const FILENAME = 'ivann';
 
-export function saveEditor(editor: EditorModel) {
+export function saveEditor(editor: EditorModel): EditorSave {
   return {
     name: editor.name,
-    editorState: editor.editor.save(),
+    state: editor.editor.save(),
   };
 }
 
@@ -24,24 +26,23 @@ export function saveEditors(editors: EditorModel[]) {
 }
 
 export function loadEditor(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  editorType: EditorType, editorSaved: any, names: Set<string>,
+  editorType: EditorType, editorSaved: EditorSave, names: Set<string>,
 ): EditorModel {
-  const { name, editorState } = editorSaved;
+  const { name, state } = editorSaved;
   const id: UUID = randomUuid();
 
   names.add(name);
 
   const editor: Editor = newEditor(editorType);
   editor.use(EditorManager.getInstance().viewPlugin);
-  editor.load(editorState);
+  editor.use(EditorManager.getInstance().engine);
+  editor.load(state);
 
   return { id, name, editor };
 }
 
 export function loadEditors(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  editorType: EditorType, editorsSaved: any, names: Set<string>,
+  editorType: EditorType, editorsSaved: EditorSave[], names: Set<string>,
 ): EditorModel[] {
   const editorsLoaded = [];
   for (const editorSaved of editorsSaved) {
@@ -49,4 +50,29 @@ export function loadEditors(
   }
 
   return editorsLoaded;
+}
+
+export class EditorSave {
+  constructor(
+    public readonly name: string,
+    public readonly state: IState,
+  ) {}
+}
+
+export class Save {
+  constructor(
+    public readonly overviewEditor: EditorSave,
+    public readonly modelEditors: EditorSave[],
+    public readonly dataEditors: EditorSave[],
+    public readonly trainEditors: EditorSave[],
+  ) {}
+}
+
+export class SaveWithNames {
+  constructor(
+    public readonly overviewEditor: string,
+    public readonly modelEditors: string[],
+    public readonly dataEditors: string[],
+    public readonly trainEditors: string[],
+  ) {}
 }

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -1,14 +1,15 @@
 import { GetterTree } from 'vuex';
 import { RootState } from '@/store/types';
-import { EditorsState } from '@/store/editors/types';
+import { EditorModels, EditorsState } from '@/store/editors/types';
 import EditorType from '@/EditorType';
 import { Nodes } from '@/nodes/model/Types';
+import { SaveWithNames } from '@/file/EditorAsJson';
 
 const editorGetters: GetterTree<EditorsState, RootState> = {
   currEditorType: (state) => state.currEditorType,
   currEditorIndex: (state) => state.currEditorIndex,
   editorNames: (state) => state.editorNames,
-  allEditorModels: (state) => ({
+  allEditorModels: (state): EditorModels => ({
     overviewEditor: state.overviewEditor,
     modelEditors: state.modelEditors,
     dataEditors: state.dataEditors,
@@ -45,6 +46,12 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
     }
     return names;
   },
+  saveWithNames: (state): SaveWithNames => ({
+    overviewEditor: state.overviewEditor.name,
+    modelEditors: state.modelEditors.map((editor) => editor.name),
+    dataEditors: state.dataEditors.map((editor) => editor.name),
+    trainEditors: state.trainEditors.map((editor) => editor.name),
+  }),
 };
 
 export default editorGetters;

--- a/src/store/editors/index.ts
+++ b/src/store/editors/index.ts
@@ -8,22 +8,16 @@ import editorMutations from './mutations';
 import { EditorsState } from './types';
 
 export const editorState: EditorsState = {
-  currEditorType: EditorType.MODEL,
+  currEditorType: EditorType.OVERVIEW,
   currEditorIndex: 0,
-  editorNames: new Set<string>(['untitled']),
+  editorNames: new Set<string>(['Overview']),
   overviewEditor: {
     // TODO: Map of editors used in overview to their nodes?
     id: randomUuid(),
     name: 'Overview',
-    editor: newEditor(EditorType.OVERVIEW), // TODO: Lazy create?
+    editor: newEditor(EditorType.OVERVIEW),
   },
-  modelEditors: [
-    {
-      id: randomUuid(),
-      name: 'untitled',
-      editor: newEditor(EditorType.MODEL),
-    },
-  ],
+  modelEditors: [],
   dataEditors: [],
   trainEditors: [],
 };

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -4,7 +4,7 @@ import { Editor } from '@baklavajs/core';
 import newEditor from '@/baklava/Utils';
 import EditorType from '@/EditorType';
 import EditorManager from '@/EditorManager';
-import { loadEditor, loadEditors } from '@/file/EditorAsJson';
+import { loadEditors, Save } from '@/file/EditorAsJson';
 import { randomUuid, UUID } from '@/app/util';
 import Model from '@/nodes/overview/Model';
 import editorIOPartition, { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
@@ -52,17 +52,20 @@ const editorMutations: MutationTree<EditorsState> = {
         break;
     }
   },
-  loadEditors(state, file) {
+  loadEditors(state, file: Save) {
     const editorNames: Set<string> = new Set<string>();
 
-    state.overviewEditor = loadEditor(EditorType.OVERVIEW, file.overviewEditor, editorNames);
+    console.log('vuexload');
+    console.log(JSON.stringify(file.overviewEditor));
+    console.log(JSON.stringify(file.dataEditors));
+    [state.overviewEditor] = loadEditors(EditorType.OVERVIEW, [file.overviewEditor], editorNames);
     state.modelEditors = loadEditors(EditorType.MODEL, file.modelEditors, editorNames);
     state.dataEditors = loadEditors(EditorType.DATA, file.dataEditors, editorNames);
     state.trainEditors = loadEditors(EditorType.TRAIN, file.trainEditors, editorNames);
 
     state.editorNames = editorNames;
 
-    state.currEditorType = EditorType.MODEL;
+    state.currEditorType = EditorType.OVERVIEW;
     state.currEditorIndex = 0;
   },
   resetState(state) {
@@ -71,17 +74,13 @@ const editorMutations: MutationTree<EditorsState> = {
       name: 'Overview',
       editor: newEditor(EditorType.OVERVIEW),
     };
-    state.modelEditors = [{
-      id: randomUuid(),
-      name: 'untitled',
-      editor: newEditor(EditorType.MODEL),
-    }];
+    state.modelEditors = [];
     state.dataEditors = [];
     state.trainEditors = [];
 
-    state.editorNames = new Set<string>(['untitled']);
+    state.editorNames = new Set<string>(['Overview']);
 
-    state.currEditorType = EditorType.MODEL;
+    state.currEditorType = EditorType.OVERVIEW;
     state.currEditorIndex = 0;
   },
   updateNodeInOverview(state, currEditor: EditorModel) {

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -55,9 +55,6 @@ const editorMutations: MutationTree<EditorsState> = {
   loadEditors(state, file: Save) {
     const editorNames: Set<string> = new Set<string>();
 
-    console.log('vuexload');
-    console.log(JSON.stringify(file.overviewEditor));
-    console.log(JSON.stringify(file.dataEditors));
     [state.overviewEditor] = loadEditors(EditorType.OVERVIEW, [file.overviewEditor], editorNames);
     state.modelEditors = loadEditors(EditorType.MODEL, file.modelEditors, editorNames);
     state.dataEditors = loadEditors(EditorType.DATA, file.dataEditors, editorNames);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -18,6 +18,8 @@ import Navbar from '@/components/navbar/Navbar.vue';
 import Editor from '@/components/Editor.vue';
 import Titlebar from '@/components/Titlebar.vue';
 import { Mutation } from 'vuex-class';
+import { Save, SaveWithNames } from '@/file/EditorAsJson';
+import EditorManager from '@/EditorManager';
 
 @Component({
   components: {
@@ -27,11 +29,19 @@ import { Mutation } from 'vuex-class';
   },
 })
 export default class Home extends Vue {
-  @Mutation('loadEditors') loadEditors!: (file: any) => void;
+  @Mutation('loadEditors') loadEditors!: (save: Save) => void;
 
   created() {
-    if (this.$cookies.isKey('unsaved')) {
-      this.loadEditors(this.$cookies.get('unsaved'));
+    // Auto-loading
+    if (this.$cookies.isKey('unsaved-project')) {
+      const saveWithNames: SaveWithNames = this.$cookies.get('unsaved-project');
+      const overviewEditor = this.$cookies.get('unsaved-editor-Overview');
+      const modelEditors = saveWithNames.modelEditors.map((name) => this.$cookies.get(`unsaved-editor-${name}`));
+      const dataEditors = saveWithNames.dataEditors.map((name) => this.$cookies.get(`unsaved-editor-${name}`));
+      const trainEditors = saveWithNames.trainEditors.map((name) => this.$cookies.get(`unsaved-editor-${name}`));
+      this.loadEditors(new Save(overviewEditor, modelEditors, dataEditors, trainEditors));
+      // We reset the view to set the panning and scaling on the current view.
+      EditorManager.getInstance().resetView();
     }
   }
 }


### PR DESCRIPTION
This PR allows partial Auto-Saving by only saving the Editor that was modified.

It also removes the default `untitled` Model Editor, and sets the Overview Editor as the default tab.

Additionally, we now have a cute Cookie Law banner at the bottom of the screen upon opening the website for the first time. I did some customisation but feel free to change anything in the theme if you want to. The classes to use are `.Cookie`, `.Cookie__content` and `.Cookie__button`.