### PR TITLE
FE-39 FE-40 Can rename and delete editors.

### DIFF
--- a/src/components/buttons/DeleteEditorButton.vue
+++ b/src/components/buttons/DeleteEditorButton.vue
@@ -1,0 +1,31 @@
+<template>
+  <span @click="deleteEditor({editorType, index})">
+    <i class="delete-button fa fa-trash"/>
+  </span>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { mapMutations } from 'vuex';
+import EditorType from '../../EditorType';
+
+@Component({
+  methods: mapMutations(['deleteEditor']),
+})
+export default class DeleteEditorButton extends Vue {
+  @Prop({ required: true }) readonly editorType!: EditorType;
+  @Prop({ required: true }) readonly index!: number;
+}
+</script>
+
+<style lang="scss" scoped>
+  .delete-button {
+    color: var(--foreground);
+    background: none;
+    padding: 0 4px 2px;
+    border-radius: 2px;
+    &:hover {
+      background: var(--blue);
+    }
+  }
+</style>

--- a/src/components/buttons/DeleteEditorButton.vue
+++ b/src/components/buttons/DeleteEditorButton.vue
@@ -7,7 +7,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { mapMutations } from 'vuex';
-import EditorType from '../../EditorType';
+import EditorType from '@/EditorType';
 
 @Component({
   methods: mapMutations(['deleteEditor']),
@@ -22,10 +22,11 @@ export default class DeleteEditorButton extends Vue {
   .delete-button {
     color: var(--foreground);
     background: none;
-    padding: 0 4px 2px;
+    padding: 0 4px 1px;
     border-radius: 2px;
+    margin: 0 4px;
     &:hover {
-      background: var(--blue);
+      background: var(--red);
     }
   }
 </style>

--- a/src/components/buttons/RenameEditorButton.vue
+++ b/src/components/buttons/RenameEditorButton.vue
@@ -1,0 +1,41 @@
+<template>
+  <span @click="this.renameEditor">
+    <i class="rename-button fa fa-pen"/>
+  </span>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Getter, Mutation } from 'vuex-class';
+import { uniqueTextInput } from '@/inputs/prompt';
+import EditorType from '../../EditorType';
+
+@Component
+export default class RenameEditorButton extends Vue {
+  @Prop({ required: true }) readonly editorType!: EditorType;
+  @Prop({ required: true }) readonly index!: number;
+  @Getter('editorNames') editorNames!: Set<string>;
+  @Mutation('renameEditor') rename!:
+    (arg0: { editorType: EditorType; index: number; name: string}) => void;
+
+  private renameEditor() {
+    const name: string | null = uniqueTextInput(this.editorNames,
+      'Please enter a unique name for the editor');
+    if (name !== null) {
+      this.rename({ editorType: this.editorType, index: this.index, name });
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+  .rename-button {
+    color: var(--foreground);
+    background: none;
+    padding: 0 4px 2px;
+    border-radius: 2px;
+    &:hover {
+      background: var(--blue);
+    }
+  }
+</style>

--- a/src/components/buttons/VerticalMenuButton.vue
+++ b/src/components/buttons/VerticalMenuButton.vue
@@ -21,18 +21,11 @@ export default class VerticalMenuButton extends Vue {
 
 <style scoped>
   .button {
-    background: #202020;
     text-align: center;
     color: #e0e0e0;
     font-size: 14px;
     padding: 10px;
-  }
-
-  .button:hover {
-    background: #1c1c1c;
-    transition-duration: 0.1s;
-    border-left-color: var(--blue);
-    cursor: pointer;
+    width: 100%;
   }
 
   .selected {

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -1,24 +1,26 @@
 <template>
-    <div id="contextual-menu">
-      <div v-for="(editor, index) in editors" :key="index">
+  <div id="contextual-menu">
+    <div v-for="(editor, index) in editors" :key="index">
+      <div>
         <div id="row">
           <VerticalMenuButton
             :label="editor.name"
             :onClick="() => switchEditor({editorType, index})"
             :isSelected="editorType === currEditorType && index === currEditorIndex">
           </VerticalMenuButton>
-          <div>
+          <div class="buttons">
             <RenameEditorButton :editorType="editorType" :index="index"/>
             <DeleteEditorButton :editorType="editorType" :index="index"/>
           </div>
         </div>
       </div>
-      <VerticalMenuButton
-        :label="'+'"
-        :onClick="this.createNewEditor"
-        :isSelected="false"
-      />
     </div>
+    <VerticalMenuButton
+      :label="'+'"
+      :onClick="this.createNewEditor"
+      :isSelected="false"
+    />
+  </div>
 </template>
 
 <script lang="ts">
@@ -47,7 +49,7 @@ export default class NavbarContextualMenu extends Vue {
   @Getter('editorNames') editorNames!: Set<string>;
   @Getter('saveWithNames') saveWithNames!: SaveWithNames;
   @Getter('currEditorModel') currEditorModel!: EditorModel;
-  @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string}) => void;
+  @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string }) => void;
 
   private createNewEditor(): void {
     const name: string | null = uniqueTextInput(this.editorNames,
@@ -63,11 +65,21 @@ export default class NavbarContextualMenu extends Vue {
 
 </script>
 
-<style scoped>
+<style lang="scss" scoped>
   #row {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    &:hover {
+      background: #1c1c1c;
+      transition-duration: 0.1s;
+      border-left-color: var(--blue);
+      cursor: pointer;
+    }
+  }
+
+  .buttons {
+    display: flex;
   }
 
   #contextual-menu {

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -1,11 +1,17 @@
 <template>
     <div id="contextual-menu">
       <div v-for="(editor, index) in editors" :key="index">
-        <VerticalMenuButton
-          :label="editor.name"
-          :onClick="() => switchEditor({ editorType, index})"
-          :isSelected="editorType === currEditorType && index === currEditorIndex">
-        </VerticalMenuButton>
+        <div id="row">
+          <VerticalMenuButton
+            :label="editor.name"
+            :onClick="() => switchEditor({editorType, index})"
+            :isSelected="editorType === currEditorType && index === currEditorIndex">
+          </VerticalMenuButton>
+          <div>
+            <RenameEditorButton :editorType="editorType" :index="index"/>
+            <DeleteEditorButton :editorType="editorType" :index="index"/>
+          </div>
+        </div>
       </div>
       <VerticalMenuButton
         :label="'+'"
@@ -24,9 +30,11 @@ import { Getter, Mutation } from 'vuex-class';
 import { EditorModel } from '@/store/editors/types';
 import { uniqueTextInput } from '@/inputs/prompt';
 import { saveEditor, SaveWithNames } from '@/file/EditorAsJson';
+import RenameEditorButton from '@/components/buttons/RenameEditorButton.vue';
+import DeleteEditorButton from '@/components/buttons/DeleteEditorButton.vue';
 
 @Component({
-  components: { VerticalMenuButton },
+  components: { VerticalMenuButton, RenameEditorButton, DeleteEditorButton },
   computed: mapGetters([
     'currEditorType',
     'currEditorIndex',
@@ -56,6 +64,12 @@ export default class NavbarContextualMenu extends Vue {
 </script>
 
 <style scoped>
+  #row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+
   #contextual-menu {
     border: 1px solid var(--grey);
   }

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -4,7 +4,7 @@ import { Editor } from '@baklavajs/core';
 import newEditor from '@/baklava/Utils';
 import EditorType from '@/EditorType';
 import EditorManager from '@/EditorManager';
-import { loadEditor, loadEditors, Save } from '@/file/EditorAsJson';
+import { loadEditors, Save } from '@/file/EditorAsJson';
 import { randomUuid, UUID } from '@/app/util';
 import Model from '@/nodes/overview/Model';
 import editorIOPartition, { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
@@ -51,6 +51,56 @@ const editorMutations: MutationTree<EditorsState> = {
       default:
         break;
     }
+  },
+  renameEditor(state, { editorType, index, name }) {
+    switch (editorType) {
+      case EditorType.MODEL:
+        state.modelEditors[index].name = name;
+        state.editorNames.delete(state.modelEditors[index].name);
+        state.editorNames.add(name);
+        break;
+      case EditorType.DATA:
+        state.dataEditors[index].name = name;
+        state.editorNames.delete(state.dataEditors[index].name);
+        state.editorNames.add(name);
+        break;
+      case EditorType.TRAIN:
+        state.trainEditors[index].name = name;
+        state.editorNames.delete(state.trainEditors[index].name);
+        state.editorNames.add(name);
+        break;
+      default:
+        break;
+    }
+  },
+  deleteEditor(state, { editorType, index }) {
+    let hasEditor = false;
+    switch (editorType) {
+      case EditorType.MODEL:
+        state.editorNames.delete(state.modelEditors[index].name);
+        state.modelEditors = state.modelEditors.filter((val, i) => i !== index);
+        hasEditor = state.modelEditors.length > 0;
+        break;
+      case EditorType.DATA:
+        state.editorNames.delete(state.dataEditors[index].name);
+        state.dataEditors = state.dataEditors.filter((val, i) => i !== index);
+        hasEditor = state.dataEditors.length > 0;
+        break;
+      case EditorType.TRAIN:
+        state.editorNames.delete(state.trainEditors[index].name);
+        state.trainEditors = state.trainEditors.filter((val, i) => i !== index);
+        hasEditor = state.trainEditors.length > 0;
+        break;
+      default:
+        break;
+    }
+
+    // If no editor left in editorType, switch to overview
+    if (!hasEditor) {
+      state.currEditorType = EditorType.OVERVIEW;
+    }
+    state.currEditorIndex = 0;
+    EditorManager.getInstance().resetView();
   },
   loadEditors(state, file: Save) {
     const editorNames: Set<string> = new Set<string>();

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -49,6 +49,7 @@ const editorMutations: MutationTree<EditorsState> = {
         }) - 1;
         break;
       default:
+        console.log('Attempted to create non existent editor type');
         break;
     }
   },
@@ -70,36 +71,43 @@ const editorMutations: MutationTree<EditorsState> = {
         state.editorNames.add(name);
         break;
       default:
+        console.log('Attempted to rename non existent editor type');
         break;
     }
   },
   deleteEditor(state, { editorType, index }) {
-    let hasEditor = false;
+    const sameEditorType = state.currEditorType === editorType;
+    const diffIndex = state.currEditorIndex - index;
+    const deletingCurr = sameEditorType && diffIndex === 0;
+
+    // If deleting current editor, switch to overview
+    if (deletingCurr) {
+      state.currEditorType = EditorType.OVERVIEW;
+      state.currEditorIndex = 0;
+    }
+
     switch (editorType) {
       case EditorType.MODEL:
         state.editorNames.delete(state.modelEditors[index].name);
         state.modelEditors = state.modelEditors.filter((val, i) => i !== index);
-        hasEditor = state.modelEditors.length > 0;
         break;
       case EditorType.DATA:
         state.editorNames.delete(state.dataEditors[index].name);
         state.dataEditors = state.dataEditors.filter((val, i) => i !== index);
-        hasEditor = state.dataEditors.length > 0;
         break;
       case EditorType.TRAIN:
         state.editorNames.delete(state.trainEditors[index].name);
         state.trainEditors = state.trainEditors.filter((val, i) => i !== index);
-        hasEditor = state.trainEditors.length > 0;
         break;
       default:
+        console.log('Attempted to delete non existent editor type');
         break;
     }
 
-    // If no editor left in editorType, switch to overview
-    if (!hasEditor) {
-      state.currEditorType = EditorType.OVERVIEW;
+    // Maintain same current editor
+    if (diffIndex > 0) {
+      state.currEditorIndex -= 1;
     }
-    state.currEditorIndex = 0;
     EditorManager.getInstance().resetView();
   },
   loadEditors(state, file: Save) {


### PR DESCRIPTION
Can rename and delete editors using the navbar contextual menu (from anywhere). 

Created a ticket (FE-61) to investigate relationship between renaming / deleting editor and editor nodes in overview - see ticket description for more details.

The behaviour when deleting an editor is if:
1) Deleting current editor - switched to overview editor
2) Else - maintain same current editor