### PR TITLE
FE-64 Implemented CodeVault skeleton.

### DIFF
--- a/src/components/CodeVault.vue
+++ b/src/components/CodeVault.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="vault">
+    <Tabs>
+      <Tab name="Functions">
+        <FunctionsTab/>
+      </Tab>
+      <Tab name="Notepad">
+        Notepad stuff goes here
+      </Tab>
+    </Tabs>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import Tabs from '@/components/tabs/Tabs.vue';
+import Tab from '@/components/tabs/Tab.vue';
+import FunctionsTab from '@/components/tabs/FunctionsTab.vue';
+
+@Component({
+  components: {
+    FunctionsTab,
+    Tab,
+    Tabs,
+  },
+})
+export default class CodeVault extends Vue {
+}
+</script>
+
+<style scoped>
+  .vault {
+    color: var(--foreground);
+    background: var(--dark-grey);
+    height: calc(100vh - 2.5rem);
+  }
+</style>

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-fluid d-flex flex-column">
+  <div class="editor container-fluid">
     <Resizable class="row" @width-change="changeWidth">
       <div class="px-0 canvas-frame"
            :style="`width: min(calc(100vw - 3rem - ${sidebarWidth}px), ${editorWidth}%)`">
@@ -53,5 +53,10 @@ export default class Editor extends Vue {
 <style scoped>
   .canvas-frame {
     min-width: 20%;
+  }
+
+  .editor {
+    display: flex;
+    flex-direction: column;
   }
 </style>

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="right">
-    <Tabs v-show="currEditorType === overviewType">
+    <Tabs v-show="currEditorType === editorType.OVERVIEW">
       <Tab name="Components">
         <ComponentsTab/>
       </Tab>
     </Tabs>
-    <Tabs v-show="currEditorType === modelType">
+    <Tabs v-show="currEditorType === editorType.MODEL">
       <Tab name="Layers">
         <LayersTab/>
       </Tab>
@@ -13,10 +13,10 @@
         <SearchTab/>
       </Tab>
     </Tabs>
-    <Tabs v-show="currEditorType === dataType">
+    <Tabs v-show="currEditorType === editorType.DATA">
       <Tab name="Data Stuff"/>
     </Tabs>
-    <Tabs v-show="currEditorType === trainType">
+    <Tabs v-show="currEditorType === editorType.TRAIN">
       <Tab name="Steam Training"/>
     </Tabs>
   </div>
@@ -43,10 +43,7 @@ import { mapGetters } from 'vuex';
   computed: mapGetters(['currEditorType']),
 })
 export default class Sidebar extends Vue {
-  private modelType = EditorType.MODEL;
-  private dataType = EditorType.DATA;
-  private trainType = EditorType.TRAIN;
-  private overviewType = EditorType.OVERVIEW;
+  private editorType = EditorType;
 }
 </script>
 

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -6,7 +6,7 @@
       :class="isSelected(editorType.OVERVIEW)"
       @click="switchEditor({editorType: editorType.OVERVIEW})"
     >
-      <i class="fas fa-hammer tab-icon"></i>
+      <i class="fas fa-hammer tab-icon"/>
     </div>
 
     <div class="py-1 px-2">
@@ -40,7 +40,7 @@
       @mouseover="displayNavbarContextualMenu(editorType.DATA)"
       @mouseleave="hideNavbarContextualMenu()"
     >
-      <i class="fas fa-database tab-icon"></i>
+      <i class="fas fa-database tab-icon"/>
       <NavbarContextualMenu
         class="navbar-contextual-menu"
         v-if="isDataContextualMenuOpen"
@@ -60,13 +60,23 @@
       @mouseover="displayNavbarContextualMenu(editorType.TRAIN)"
       @mouseleave="hideNavbarContextualMenu()"
     >
-      <i class="fas fa-cogs tab-icon"></i>
+      <i class="fas fa-cogs tab-icon"/>
       <NavbarContextualMenu
         class="navbar-contextual-menu"
         v-if="isTrainContextualMenuOpen"
         :editors="trainEditors"
         :editor-type="editorType.TRAIN"
       />
+    </div>
+
+    <!-- Code Vault -->
+    <div class="flex-grow-1"/>
+    <div
+      class="build tab-button"
+      :class="inCodeVault && 'selected'"
+      @click="enterCodeVault"
+    >
+      <i class="fab fa-python tab-icon"/>
     </div>
   </div>
 </template>
@@ -84,8 +94,9 @@ import NavbarContextualMenu from '@/components/navbar/NavbarContextualMenu.vue';
     'modelEditors',
     'dataEditors',
     'trainEditors',
+    'inCodeVault',
   ]),
-  methods: mapMutations(['switchEditor']),
+  methods: mapMutations(['switchEditor', 'enterCodeVault']),
 })
 export default class Navbar extends Vue {
   private editorType = EditorType;
@@ -93,9 +104,10 @@ export default class Navbar extends Vue {
   private isDataContextualMenuOpen = false;
   private isTrainContextualMenuOpen = false;
   @Getter('currEditorType') currEditorType!: EditorType;
+  @Getter('inCodeVault') inCodeVault!: boolean;
 
-  private isSelected(editorType: EditorType) {
-    return (this.currEditorType === editorType) ? 'selected' : '';
+  private isSelected(editorType?: EditorType) {
+    return !this.inCodeVault && (this.currEditorType === editorType) ? 'selected' : '';
   }
 
   private displayNavbarContextualMenu(editorType: EditorType) {

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -106,7 +106,7 @@ export default class Navbar extends Vue {
   @Getter('currEditorType') currEditorType!: EditorType;
   @Getter('inCodeVault') inCodeVault!: boolean;
 
-  private isSelected(editorType?: EditorType) {
+  private isSelected(editorType: EditorType) {
     return !this.inCodeVault && (this.currEditorType === editorType) ? 'selected' : '';
   }
 

--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    Function Stuff goes here
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import Tabs from '@/components/tabs/Tabs.vue';
+import Tab from '@/components/tabs/Tab.vue';
+
+@Component({
+  components: {
+    Tab,
+    Tabs,
+  },
+})
+export default class FunctionsTab extends Vue {
+}
+</script>
+
+<style scoped>
+</style>

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -52,6 +52,7 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
     dataEditors: state.dataEditors.map((editor) => editor.name),
     trainEditors: state.trainEditors.map((editor) => editor.name),
   }),
+  inCodeVault: (state) => state.inCodeVault,
 };
 
 export default editorGetters;

--- a/src/store/editors/index.ts
+++ b/src/store/editors/index.ts
@@ -20,6 +20,7 @@ export const editorState: EditorsState = {
   modelEditors: [],
   dataEditors: [],
   trainEditors: [],
+  inCodeVault: false,
 };
 
 export const editors: Module<EditorsState, RootState> = {

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -12,6 +12,7 @@ import { getEditorIOs } from '@/store/editors/utils';
 
 const editorMutations: MutationTree<EditorsState> = {
   switchEditor(state, { editorType, index }) {
+    state.inCodeVault = false;
     state.currEditorType = editorType;
     state.currEditorIndex = index;
     EditorManager.getInstance().resetView();
@@ -156,6 +157,9 @@ const editorMutations: MutationTree<EditorsState> = {
         overviewNode.updateIO(inputChange, outputChange);
       }
     }
+  },
+  enterCodeVault(state) {
+    state.inCodeVault = true;
   },
 };
 

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -18,6 +18,7 @@ const editorMutations: MutationTree<EditorsState> = {
     EditorManager.getInstance().resetView();
   },
   newEditor(state, { editorType, name }) {
+    state.inCodeVault = false;
     const id: UUID = randomUuid();
     const editor: Editor = newEditor(editorType);
 

--- a/src/store/editors/types.ts
+++ b/src/store/editors/types.ts
@@ -19,4 +19,5 @@ export interface EditorsState extends EditorModels {
   currEditorType: EditorType;
   currEditorIndex: number;
   editorNames: Set<string>;
+  inCodeVault: boolean;
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -6,7 +6,8 @@
         <Navbar />
       </div>
       <div class="col d-flex flex-column p-0">
-        <Editor />
+        <Editor v-show="!inCodeVault"/>
+        <CodeVault v-show="inCodeVault"/>
       </div>
     </div>
   </div>
@@ -20,13 +21,17 @@ import Titlebar from '@/components/Titlebar.vue';
 import { Mutation } from 'vuex-class';
 import { Save, SaveWithNames } from '@/file/EditorAsJson';
 import EditorManager from '@/EditorManager';
+import { mapGetters } from 'vuex';
+import CodeVault from '@/components/CodeVault.vue';
 
 @Component({
   components: {
+    CodeVault,
     Titlebar,
     Navbar,
     Editor,
   },
+  computed: mapGetters(['inCodeVault']),
 })
 export default class Home extends Vue {
   @Mutation('loadEditors') loadEditors!: (save: Save) => void;

--- a/tests/unit/store/editors/mockData.ts
+++ b/tests/unit/store/editors/mockData.ts
@@ -35,4 +35,5 @@ export const mockEditorState: EditorsState = {
   modelEditors: mockModelEditors,
   dataEditors: [],
   trainEditors: [],
+  inCodeVault: false,
 };


### PR DESCRIPTION
Created a new 'editor' on the navbar for the code vault. Updated state to have a `inCodeVault` field so that there remains a link between the `currEditor` for Baklava, and the code vault (e.g. when doing things with `CustomNode`s). Implemented the basic tab interface.