### PR TITLE
FE-60 FE-61 Save editors periodically and update overview on rename + delete

### DIFF
--- a/src/components/Titlebar.vue
+++ b/src/components/Titlebar.vue
@@ -50,6 +50,7 @@ import istateToGraph from '@/app/ir/istateToGraph';
 @Component
 export default class Titlebar extends Vue {
   @Getter('allEditorModels') editorModels!: EditorModels;
+  @Getter('currEditorModel') overviewEditor!: EditorModel;
   @Getter('currEditorModel') currEditor!: EditorModel;
   @Getter('saveWithNames') saveWithNames!: SaveWithNames;
   @Mutation('loadEditors') loadEditors!: (save: Save) => void;
@@ -77,8 +78,11 @@ export default class Titlebar extends Vue {
     fr.onload = (event) => {
       if (!event.target) return;
 
-      // Load all editors using parsed file
+      // Load all editors using parsed file and set cookies
       this.loadEditors(JSON.parse(event.target.result as string));
+      this.$cookies.keys().forEach((key) => this.$cookies.remove(key));
+      this.$cookies.set('unsaved-project', this.saveWithNames);
+      // TODO: FE-65 Set cookies for all editors
     };
 
     // Trigger the file to be read

--- a/src/components/buttons/DeleteEditorButton.vue
+++ b/src/components/buttons/DeleteEditorButton.vue
@@ -1,20 +1,37 @@
 <template>
-  <span @click="deleteEditor({editorType, index})">
+  <span @click="deleteEditor">
     <i class="delete-button fa fa-trash"/>
   </span>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { mapMutations } from 'vuex';
 import EditorType from '@/EditorType';
+import { Getter, Mutation } from 'vuex-class';
+import { saveEditor, SaveWithNames } from '@/file/EditorAsJson';
+import { EditorModel } from '@/store/editors/types';
 
-@Component({
-  methods: mapMutations(['deleteEditor']),
-})
+@Component
 export default class DeleteEditorButton extends Vue {
   @Prop({ required: true }) readonly editorType!: EditorType;
   @Prop({ required: true }) readonly index!: number;
+  @Prop({ required: true }) readonly name!: string;
+  @Getter('overviewEditor') overviewEditor!: EditorModel;
+  @Getter('saveWithNames') saveWithNames!: SaveWithNames;
+  @Mutation('deleteEditor') delete!:
+    (arg0: { editorType: EditorType; index: number; name: string }) => void;
+
+  private deleteEditor() {
+    this.delete({ editorType: this.editorType, index: this.index, name: this.name });
+
+    // Re-save overview after nodes may have been removed
+    const overviewEditorSave = saveEditor(this.overviewEditor);
+    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+
+    // Remove deleted editor from saved cookies
+    this.$cookies.remove(`unsaved-editor-${this.name}`);
+    this.$cookies.set('unsaved-project', this.saveWithNames);
+  }
 }
 </script>
 

--- a/src/components/buttons/RenameEditorButton.vue
+++ b/src/components/buttons/RenameEditorButton.vue
@@ -8,21 +8,42 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { Getter, Mutation } from 'vuex-class';
 import { uniqueTextInput } from '@/inputs/prompt';
-import EditorType from '../../EditorType';
+import { EditorSave, saveEditor, SaveWithNames } from '@/file/EditorAsJson';
+import EditorType from '@/EditorType';
+import { EditorModel } from '@/store/editors/types';
 
 @Component
 export default class RenameEditorButton extends Vue {
   @Prop({ required: true }) readonly editorType!: EditorType;
   @Prop({ required: true }) readonly index!: number;
+  @Prop({ required: true }) readonly oldName!: string;
   @Getter('editorNames') editorNames!: Set<string>;
+  @Getter('saveWithNames') saveWithNames!: SaveWithNames;
+  @Getter('editor') getEditor!: (editorType: EditorType, index: number) => EditorModel;
+  @Getter('overviewEditor') overviewEditor!: EditorModel;
   @Mutation('renameEditor') rename!:
-    (arg0: { editorType: EditorType; index: number; name: string}) => void;
+    (arg0: { editorType: EditorType; index: number; name: string; oldName: string }) => void;
 
   private renameEditor() {
     const name: string | null = uniqueTextInput(this.editorNames,
       'Please enter a unique name for the editor');
     if (name !== null) {
-      this.rename({ editorType: this.editorType, index: this.index, name });
+      this.rename({
+        editorType: this.editorType,
+        index: this.index,
+        name,
+        oldName: this.oldName,
+      });
+
+      // Re-save overview to get new node name
+      const overviewEditorSave = saveEditor(this.overviewEditor);
+      this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+
+      // Replace cookie with updated name
+      const saved: EditorSave = saveEditor(this.getEditor(this.editorType, this.index));
+      this.$cookies.set(`unsaved-editor-${name}`, saved);
+      this.$cookies.set('unsaved-project', this.saveWithNames);
+      this.$cookies.remove(`unsaved-editor-${this.oldName}`);
     }
   }
 }

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -9,8 +9,8 @@
             :isSelected="editorType === currEditorType && index === currEditorIndex">
           </VerticalMenuButton>
           <div class="buttons">
-            <RenameEditorButton :editorType="editorType" :index="index"/>
-            <DeleteEditorButton :editorType="editorType" :index="index"/>
+            <RenameEditorButton :editorType="editorType" :index="index" :oldName="editor.name"/>
+            <DeleteEditorButton :editorType="editorType" :index="index" :name="editor.name"/>
           </div>
         </div>
       </div>
@@ -31,7 +31,6 @@ import EditorType from '@/EditorType';
 import { Getter, Mutation } from 'vuex-class';
 import { EditorModel } from '@/store/editors/types';
 import { uniqueTextInput } from '@/inputs/prompt';
-import { saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 import RenameEditorButton from '@/components/buttons/RenameEditorButton.vue';
 import DeleteEditorButton from '@/components/buttons/DeleteEditorButton.vue';
 
@@ -47,8 +46,6 @@ export default class NavbarContextualMenu extends Vue {
   @Prop({ required: true }) readonly editors!: EditorModel[];
   @Prop({ required: true }) readonly editorType!: EditorType;
   @Getter('editorNames') editorNames!: Set<string>;
-  @Getter('saveWithNames') saveWithNames!: SaveWithNames;
-  @Getter('currEditorModel') currEditorModel!: EditorModel;
   @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string }) => void;
 
   private createNewEditor(): void {
@@ -56,9 +53,7 @@ export default class NavbarContextualMenu extends Vue {
       'Please enter a unique name for the editor');
     if (name !== null) {
       this.newEditor({ editorType: this.editorType, name });
-      // Auto-Saving this new Editor
-      this.$cookies.set('unsaved-project', this.saveWithNames);
-      this.$cookies.set(`unsaved-editor-${name}`, saveEditor(this.currEditorModel));
+      // New editor will be saved in periodic auto-save
     }
   }
 }

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -37,6 +37,20 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
   modelEditor: (state) => (index: number) => state.modelEditors[index],
   dataEditor: (state) => (index: number) => state.dataEditors[index],
   trainEditor: (state) => (index: number) => state.trainEditors[index],
+  editor: (state) => (editorType: EditorType, index: number) => {
+    switch (editorType) {
+      case EditorType.OVERVIEW:
+        return state.overviewEditor;
+      case EditorType.MODEL:
+        return state.modelEditors[index];
+      case EditorType.DATA:
+        return state.dataEditors[index];
+      case EditorType.TRAIN:
+        return state.trainEditors[index];
+      default:
+        return {};
+    }
+  },
   editorIONames: (state, getters) => {
     const names: Set<string> = new Set<string>();
     for (const node of getters.currEditorModel.editor.nodes) {

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -53,7 +53,9 @@ const editorMutations: MutationTree<EditorsState> = {
         break;
     }
   },
-  renameEditor(state, { editorType, index, name }) {
+  renameEditor(state, {
+    editorType, index, name, oldName,
+  }) {
     switch (editorType) {
       case EditorType.MODEL:
         state.modelEditors[index].name = name;
@@ -74,8 +76,14 @@ const editorMutations: MutationTree<EditorsState> = {
         console.log('Attempted to rename non existent editor type');
         break;
     }
+
+    // Loop through nodes in overview editor, find corresponding nodes and rename them
+    const { nodes } = state.overviewEditor.editor;
+    for (const node of nodes) {
+      if (node.name === oldName) node.name = name;
+    }
   },
-  deleteEditor(state, { editorType, index }) {
+  deleteEditor(state, { editorType, index, name }) {
     const sameEditorType = state.currEditorType === editorType;
     const diffIndex = state.currEditorIndex - index;
     const deletingCurr = sameEditorType && diffIndex === 0;
@@ -109,6 +117,12 @@ const editorMutations: MutationTree<EditorsState> = {
       state.currEditorIndex -= 1;
     }
     EditorManager.getInstance().resetView();
+
+    // Loop through nodes in overview editor, find corresponding nodes and delete them
+    const { nodes } = state.overviewEditor.editor;
+    for (const node of nodes) {
+      if (node.name === name) state.overviewEditor.editor.removeNode(node);
+    }
   },
   loadEditors(state, file: Save) {
     const editorNames: Set<string> = new Set<string>();

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -17,9 +17,10 @@ import { Component, Vue } from 'vue-property-decorator';
 import Navbar from '@/components/navbar/Navbar.vue';
 import Editor from '@/components/Editor.vue';
 import Titlebar from '@/components/Titlebar.vue';
-import { Mutation } from 'vuex-class';
-import { Save, SaveWithNames } from '@/file/EditorAsJson';
+import { Getter, Mutation } from 'vuex-class';
+import { Save, saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 import EditorManager from '@/EditorManager';
+import { EditorModel } from '@/store/editors/types';
 
 @Component({
   components: {
@@ -29,7 +30,11 @@ import EditorManager from '@/EditorManager';
   },
 })
 export default class Home extends Vue {
+  @Getter('currEditorModel') currEditorModel!: EditorModel;
+  @Getter('overviewEditor') overviewEditor!: EditorModel;
+  @Getter('saveWithNames') saveWithNames!: SaveWithNames;
   @Mutation('loadEditors') loadEditors!: (save: Save) => void;
+  @Mutation('updateNodeInOverview') readonly updateNodeInOverview!: (cEditor: EditorModel) => void;
 
   created() {
     // Auto-loading
@@ -43,6 +48,20 @@ export default class Home extends Vue {
       // We reset the view to set the panning and scaling on the current view.
       EditorManager.getInstance().resetView();
     }
+
+    // Set up auto-save every 5 seconds
+    setInterval(() => {
+      // Update overview editor if required
+      this.updateNodeInOverview(this.currEditorModel);
+
+      // Auto-saving, have to save Overview as that may have changed passively
+      const currEditorSave = saveEditor(this.currEditorModel);
+      const overviewEditorSave = saveEditor(this.overviewEditor);
+
+      this.$cookies.set('unsaved-project', this.saveWithNames);
+      this.$cookies.set(`unsaved-editor-${this.currEditorModel.name}`, currEditorSave);
+      this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+    }, 5000);
   }
 }
 </script>


### PR DESCRIPTION
Save editors every 5 seconds. 
Save editor you came from when switching editors so you capture any last second changes
Save editor new name on rename
Delete editor cookie on delete

NOTE: Do not save on new editor as that will be done in at most 5 seconds time

Delete node in overview on editor delete
Rename node in overview on editor rename

TODO: FE-65 Set cookies after loading editors from file (currently only clear cookies)
TODO: Disable renaming of nodes in overview??????