### PR TITLE
Refactored rename and delete mutations and update overview on switch

### DIFF
--- a/src/baklava/Utils.ts
+++ b/src/baklava/Utils.ts
@@ -32,11 +32,6 @@ export default function newEditor(editorType: EditorType) {
       break;
   }
 
-  // Guarantee calculate is called on removal of node
-  editor.events.removeNode.addListener(editor, () => {
-    EditorManager.getInstance().engine.calculate();
-  });
-
   if (canvas) {
     editor.use(canvas.optionPlugin);
     canvas.registerNodes(editor);

--- a/src/components/buttons/DeleteEditorButton.vue
+++ b/src/components/buttons/DeleteEditorButton.vue
@@ -18,11 +18,10 @@ export default class DeleteEditorButton extends Vue {
   @Prop({ required: true }) readonly name!: string;
   @Getter('overviewEditor') overviewEditor!: EditorModel;
   @Getter('saveWithNames') saveWithNames!: SaveWithNames;
-  @Mutation('deleteEditor') delete!:
-    (arg0: { editorType: EditorType; index: number; name: string }) => void;
+  @Mutation('deleteEditor') delete!: (arg0: { editorType: EditorType; index: number }) => void;
 
   private deleteEditor() {
-    this.delete({ editorType: this.editorType, index: this.index, name: this.name });
+    this.delete({ editorType: this.editorType, index: this.index });
 
     // Re-save overview after nodes may have been removed
     const overviewEditorSave = saveEditor(this.overviewEditor);

--- a/src/components/buttons/RenameEditorButton.vue
+++ b/src/components/buttons/RenameEditorButton.vue
@@ -22,18 +22,13 @@ export default class RenameEditorButton extends Vue {
   @Getter('editor') getEditor!: (editorType: EditorType, index: number) => EditorModel;
   @Getter('overviewEditor') overviewEditor!: EditorModel;
   @Mutation('renameEditor') rename!:
-    (arg0: { editorType: EditorType; index: number; name: string; oldName: string }) => void;
+    (arg0: { editorType: EditorType; index: number; name: string }) => void;
 
   private renameEditor() {
     const name: string | null = uniqueTextInput(this.editorNames,
       'Please enter a unique name for the editor');
     if (name !== null) {
-      this.rename({
-        editorType: this.editorType,
-        index: this.index,
-        name,
-        oldName: this.oldName,
-      });
+      this.rename({ editorType: this.editorType, index: this.index, name });
 
       // Re-save overview to get new node name
       const overviewEditorSave = saveEditor(this.overviewEditor);

--- a/src/components/canvas/Canvas.vue
+++ b/src/components/canvas/Canvas.vue
@@ -11,31 +11,22 @@ import {
   Vue,
   Watch,
 } from 'vue-property-decorator';
-import { Getter, Mutation } from 'vuex-class';
 import { Engine } from '@baklavajs/plugin-engine';
 import { ViewPlugin } from '@baklavajs/plugin-renderer-vue';
 import { EditorModel } from '@/store/editors/types';
 import istateToGraph from '@/app/ir/istateToGraph';
-import { EditorSave, saveEditor } from '@/file/EditorAsJson';
+import { saveEditor } from '@/file/EditorAsJson';
 
 @Component
 export default class Canvas extends Vue {
   @Prop({ required: true }) readonly viewPlugin!: ViewPlugin;
   @Prop({ required: true }) readonly engine!: Engine;
   @Prop({ required: true }) readonly editorModel!: EditorModel;
-  @Getter('overviewEditor') overviewEditor!: EditorModel;
-  @Mutation('updateNodeInOverview') readonly updateNodeInOverview!: (cEditor: EditorModel) => void;
 
   @Watch('editorModel')
-  onEditorChange(newEditorModel: EditorModel, oldEditorModel: EditorModel) {
+  onEditorChange(newEditorModel: EditorModel) {
     newEditorModel.editor.use(this.viewPlugin);
     newEditorModel.editor.use(this.engine);
-
-    // Save oldEditorModel as periodic save may not have captured last changes
-    const oldEditorSaved: EditorSave = saveEditor(oldEditorModel);
-    const overviewEditorSave: EditorSave = saveEditor(this.overviewEditor);
-    this.$cookies.set(`unsaved-editor-${oldEditorModel.name}`, oldEditorSaved);
-    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
   }
 
   created(): void {

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -5,7 +5,7 @@
         <div id="row">
           <VerticalMenuButton
             :label="editor.name"
-            :onClick="() => switchEditor({editorType, index})"
+            :onClick="() => switchEditor(editorType, index)"
             :isSelected="editorType === currEditorType && index === currEditorIndex">
           </VerticalMenuButton>
           <div class="buttons">
@@ -26,13 +26,14 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import VerticalMenuButton from '@/components/buttons/VerticalMenuButton.vue';
-import { mapGetters, mapMutations } from 'vuex';
+import { mapGetters } from 'vuex';
 import EditorType from '@/EditorType';
 import { Getter, Mutation } from 'vuex-class';
 import { EditorModel } from '@/store/editors/types';
 import { uniqueTextInput } from '@/inputs/prompt';
 import RenameEditorButton from '@/components/buttons/RenameEditorButton.vue';
 import DeleteEditorButton from '@/components/buttons/DeleteEditorButton.vue';
+import { EditorSave, saveEditor } from '@/file/EditorAsJson';
 
 @Component({
   components: { VerticalMenuButton, RenameEditorButton, DeleteEditorButton },
@@ -40,13 +41,16 @@ import DeleteEditorButton from '@/components/buttons/DeleteEditorButton.vue';
     'currEditorType',
     'currEditorIndex',
   ]),
-  methods: mapMutations(['switchEditor']),
 })
 export default class NavbarContextualMenu extends Vue {
   @Prop({ required: true }) readonly editors!: EditorModel[];
   @Prop({ required: true }) readonly editorType!: EditorType;
   @Getter('editorNames') editorNames!: Set<string>;
+  @Getter('currEditorModel') currEditorModel!: EditorModel;
+  @Getter('overviewEditor') overviewEditor!: EditorModel;
   @Mutation('newEditor') newEditor!: (arg0: { editorType: EditorType; name: string }) => void;
+  @Mutation('switchEditor') switch!: (arg0: { editorType: EditorType; index: number }) => void;
+  @Mutation('updateNodeInOverview') readonly updateNodeInOverview!: (cEditor: EditorModel) => void;
 
   private createNewEditor(): void {
     const name: string | null = uniqueTextInput(this.editorNames,
@@ -55,6 +59,19 @@ export default class NavbarContextualMenu extends Vue {
       this.newEditor({ editorType: this.editorType, name });
       // New editor will be saved in periodic auto-save
     }
+  }
+
+  private switchEditor(editorType: EditorType, index: number) {
+    // Save currEditorModel before switching as periodic save may not have captured last changes
+    // and update overview editor if required
+    this.updateNodeInOverview(this.currEditorModel);
+
+    const oldEditorSaved: EditorSave = saveEditor(this.currEditorModel);
+    const overviewEditorSave: EditorSave = saveEditor(this.overviewEditor);
+    this.$cookies.set(`unsaved-editor-${this.currEditorModel.name}`, oldEditorSaved);
+    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+
+    this.switch({ editorType, index });
   }
 }
 

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -55,23 +55,23 @@ const editorMutations: MutationTree<EditorsState> = {
         break;
     }
   },
-  renameEditor(state, {
-    editorType, index, name, oldName,
-  }) {
+  renameEditor(state, { editorType, index, name }) {
+    let oldName: string | null = null;
+
     switch (editorType) {
       case EditorType.MODEL:
+        oldName = state.modelEditors[index].name;
         state.modelEditors[index].name = name;
-        state.editorNames.delete(state.modelEditors[index].name);
         state.editorNames.add(name);
         break;
       case EditorType.DATA:
+        oldName = state.dataEditors[index].name;
         state.dataEditors[index].name = name;
-        state.editorNames.delete(state.dataEditors[index].name);
         state.editorNames.add(name);
         break;
       case EditorType.TRAIN:
+        oldName = state.trainEditors[index].name;
         state.trainEditors[index].name = name;
-        state.editorNames.delete(state.trainEditors[index].name);
         state.editorNames.add(name);
         break;
       default:
@@ -79,13 +79,19 @@ const editorMutations: MutationTree<EditorsState> = {
         break;
     }
 
-    // Loop through nodes in overview editor, find corresponding nodes and rename them
-    const { nodes } = state.overviewEditor.editor;
-    for (const node of nodes) {
-      if (node.name === oldName) node.name = name;
+    if (oldName !== null) {
+      state.editorNames.delete(oldName);
+
+      // Loop through nodes in overview editor, find corresponding nodes and rename them
+      const { nodes } = state.overviewEditor.editor;
+      for (const node of nodes) {
+        if (node.name === oldName) node.name = name;
+      }
     }
   },
-  deleteEditor(state, { editorType, index, name }) {
+  deleteEditor(state, { editorType, index }) {
+    let name: string | null = null;
+
     const sameEditorType = state.currEditorType === editorType;
     const diffIndex = state.currEditorIndex - index;
     const deletingCurr = sameEditorType && diffIndex === 0;
@@ -98,15 +104,15 @@ const editorMutations: MutationTree<EditorsState> = {
 
     switch (editorType) {
       case EditorType.MODEL:
-        state.editorNames.delete(state.modelEditors[index].name);
+        name = state.modelEditors[index].name;
         state.modelEditors = state.modelEditors.filter((val, i) => i !== index);
         break;
       case EditorType.DATA:
-        state.editorNames.delete(state.dataEditors[index].name);
+        name = state.dataEditors[index].name;
         state.dataEditors = state.dataEditors.filter((val, i) => i !== index);
         break;
       case EditorType.TRAIN:
-        state.editorNames.delete(state.trainEditors[index].name);
+        name = state.trainEditors[index].name;
         state.trainEditors = state.trainEditors.filter((val, i) => i !== index);
         break;
       default:
@@ -120,10 +126,14 @@ const editorMutations: MutationTree<EditorsState> = {
     }
     EditorManager.getInstance().resetView();
 
-    // Loop through nodes in overview editor, find corresponding nodes and delete them
-    const { nodes } = state.overviewEditor.editor;
-    for (const node of nodes) {
-      if (node.name === name) state.overviewEditor.editor.removeNode(node);
+    if (name !== null) {
+      state.editorNames.delete(name);
+
+      // Loop through nodes in overview editor, find corresponding nodes and delete them
+      const { nodes } = state.overviewEditor.editor;
+      for (const node of nodes) {
+        if (node.name === name) state.overviewEditor.editor.removeNode(node);
+      }
     }
   },
   loadEditors(state, file: Save) {


### PR DESCRIPTION
No longer need to pass in name of editor you are renaming to `renameEditor` mutation
No longer need to pass in name of editor you are deleting to `deleteEditor` mutation

Update overview when switching editors as may have changed something in last 5 seconds that has not been saved just before switching editors. Also moved the code for this from `canvas.vue` to `switchEditor` method.