### PR TITLE
FE-76,FE-77 Use ParsedFunction in Custom Nodes

### DIFF
--- a/src/app/parser/ParsedFunction.ts
+++ b/src/app/parser/ParsedFunction.ts
@@ -5,6 +5,11 @@ class ParsedFunction {
     public readonly args: string[],
   ) {
   }
+
+  public toString(): string {
+    return `def ${this.name}(${this.args.join(', ')}):\n`
+      + `${this.body}`;
+  }
 }
 
 export default ParsedFunction;

--- a/src/app/parser/parser.ts
+++ b/src/app/parser/parser.ts
@@ -13,6 +13,10 @@ function getIndentation(file: string): string | null {
     const line = lines[i];
 
     if (line.length > 0) {
+      // If there is no character on the line
+      if (line.search(/\S/) < 0) {
+        return null;
+      }
       // Indent is with spaces
       if (line[0] === ' ') {
         return ' '.repeat(line.search(/\S/));
@@ -73,7 +77,7 @@ function parse(str: string): Result<ParsedFunction[]> {
     if (isParsingFunction) {
       if (isLineIndented(line, indentation)) {
         if (!isParsingFunction) {
-          return new Error(`unexpected indentation at line ${i}: ${line}`);
+          return new Error(`unexpected indentation at line ${i + 1}: ${line}`);
         }
 
         // Parsing function body
@@ -95,7 +99,7 @@ function parse(str: string): Result<ParsedFunction[]> {
         const signature = parseFunctionSignature(line);
 
         if (signature === null) {
-          return new Error(`failed to parse function definition at line ${i}: ${line}`);
+          return new Error(`failed to parse function definition at line ${i + 1}: ${line}`);
         }
 
         isParsingFunction = true;
@@ -104,7 +108,7 @@ function parse(str: string): Result<ParsedFunction[]> {
       }
 
       if (isLineIndented(line, indentation)) {
-        return new Error(`unexpected indentation at line ${i}: ${line}`);
+        return new Error(`unexpected indentation at line ${i + 1}: ${line}`);
       }
     }
   }

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -22,6 +22,9 @@ import '@/assets/ivann-theme';
 import { Getter, Mutation } from 'vuex-class';
 import Custom from '@/nodes/model/custom/Custom';
 import UIButton from '@/components/buttons/UIButton.vue';
+import parse from '@/app/parser/parser';
+import ParsedFunction from '@/app/parser/ParsedFunction';
+import { Result } from '@/app/util';
 
 @Component({
   components: {
@@ -37,20 +40,15 @@ export default class IdeTab extends Vue {
   @Mutation('linkNode') linkNode!: (node?: Custom) => void;
   private editor?: Ace.Editor;
 
+  private parsedFunction?: Result<ParsedFunction>;
+
   /**
    * Watches the rendering of the CodeVault in order to update code.
-   * If the CodeVault was entered from a Custom Node, update code.
-   * Else, set empty the editor.
    */
   @Watch('inCodeVault')
   private onInCodeVaultChanged(inCodeVault: boolean) {
     if (inCodeVault && this.editor) {
-      if (this.nodeTriggeringCodeVault) {
-        this.editor.setValue(this.nodeTriggeringCodeVault.getInlineCode());
-      } else {
-        this.editor.setValue('');
-      }
-      this.editor.clearSelection();
+      this.updateCode();
     }
   }
 
@@ -59,23 +57,77 @@ export default class IdeTab extends Vue {
     this.editor.getSession().setMode('ace/mode/python');
     this.editor.setTheme('ace/theme/ivann');
     this.editor.resize(true);
+    this.editor.setOptions({
+      tabSize: 2,
+      useSoftTabs: true,
+    });
     this.editor.$blockScrolling = Infinity; // Get rid unnecessary Console info
-    if (this.nodeTriggeringCodeVault) {
-      this.editor.setValue(this.nodeTriggeringCodeVault.getInlineCode());
-      this.editor.clearSelection();
-    }
+    this.editor.on('change', this.onEditorChange);
+
+    this.updateCode();
   }
 
   private save() {
     if (this.nodeTriggeringCodeVault && this.editor) {
-      this.nodeTriggeringCodeVault.setInlineCode(this.editor.getValue());
+      if (!(this.parsedFunction instanceof Error)) {
+        this.nodeTriggeringCodeVault.setInlineCode(this.parsedFunction);
+        this.leaveCodeVault();
+      } else {
+        window.alert('Cannot save function with errors.');
+      }
     }
-    this.leaveCodeVault();
   }
 
   private cancel() {
     this.leaveCodeVault();
     this.linkNode(undefined); // Unlink node.
+  }
+
+  /**
+   * On Editor Change, parses the code and shows an Error if there is one.
+   */
+  private onEditorChange() {
+    if (this.editor) {
+      const code = this.editor.getValue();
+      const functionsOrError = parse(code);
+      if (!(functionsOrError instanceof Error)) {
+        if (functionsOrError.length > 0) {
+          this.editor.getSession().clearAnnotations();
+          [this.parsedFunction] = functionsOrError;
+        }
+      } else {
+        this.showError(functionsOrError);
+        this.parsedFunction = functionsOrError;
+      }
+    }
+  }
+
+  private showError(error: Error) {
+    if (this.editor) {
+      this.editor.getSession().setAnnotations([{
+        row: 0,
+        column: 0,
+        text: error.message,
+        type: 'error',
+      }]);
+    }
+  }
+  /**
+   * If the CodeVault was entered from a Custom Node, update code.
+   * Else, empties the editor.
+   */
+  private updateCode() {
+    if (this.editor) {
+      if (this.nodeTriggeringCodeVault) {
+        const inlineCode = this.nodeTriggeringCodeVault.getInlineCode();
+        if (inlineCode) {
+          this.editor.setValue(inlineCode.toString());
+        }
+      } else {
+        this.editor.setValue('');
+      }
+      this.editor.clearSelection();
+    }
   }
 }
 </script>

--- a/src/store/codeVault/mutations.ts
+++ b/src/store/codeVault/mutations.ts
@@ -44,7 +44,6 @@ const codeVaultMutations: MutationTree<CodeVaultState> = {
   },
   linkNode(state, node?: Custom) {
     state.nodeTriggeringCodeVault = node;
-    console.log(`New code: ${state.nodeTriggeringCodeVault?.getInlineCode()}`);
   },
 };
 

--- a/tests/unit/app/parser/ParsedFunction.spec.ts
+++ b/tests/unit/app/parser/ParsedFunction.spec.ts
@@ -1,0 +1,30 @@
+import ParsedFunction from '@/app/parser/ParsedFunction';
+
+describe('parsedFunction', () => {
+  it('stringifies a function with args correctly', () => {
+    const parsedFunction = new ParsedFunction(
+      'func',
+      '  line1\n  line2\n',
+      ['arg1', 'arg2'],
+    );
+
+    const expected = 'def func(arg1, arg2):\n'
+      + '  line1\n'
+      + '  line2\n';
+
+    expect(parsedFunction.toString()).toBe(expected);
+  });
+
+  it('stringifies a function without args correctly', () => {
+    const parsedFunction = new ParsedFunction(
+      'func',
+      '  line1\n  line2\n',
+      [],
+    );
+    const expected = 'def func():\n'
+      + '  line1\n'
+      + '  line2\n';
+
+    expect(parsedFunction.toString()).toBe(expected);
+  });
+});


### PR DESCRIPTION
This PR adds the usage of the `ParsedFunction` class in Custom Nodes. Additionally, it adds a `toString()` method to the class in order to retrieve the inline code from the parsed function.

While waiting for the Functions Tab to be done, the IDEA still directly gets the code from the Custom Node and now shows if there are errors.