### PR TITLE
FE-79 Add Custom Node in other editors and refactor Registering Nodes

### DIFF
--- a/src/app/ir/Custom.ts
+++ b/src/app/ir/Custom.ts
@@ -1,4 +1,4 @@
-import { CustomOptions } from '@/nodes/model/custom/Custom';
+import { CustomOptions } from '@/nodes/common/Custom';
 
 class Custom {
   public readonly name = 'custom'

--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -106,7 +106,9 @@
 import { Component } from 'vue-property-decorator';
 import { Components } from '@baklavajs/plugin-renderer-vue';
 import ArrowButton from '@/inputs/ArrowButton.vue';
-import { Nodes, Overview } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
+import { OverviewNodes } from '@/nodes/overview/Types';
+import { CommonNodes } from '@/nodes/common/Types';
 
 @Component({
   components: { ArrowButton },
@@ -123,7 +125,7 @@ export default class CustomNode extends Components.Node {
 
   private getContextualMenuItems() {
     const items = [{ value: 'delete', label: 'Delete' }];
-    if (this.data.type !== Overview.ModelNode) {
+    if (this.data.type !== OverviewNodes.ModelNode) {
       items.unshift({ value: 'rename', label: 'Rename' });
     }
     return items;
@@ -135,17 +137,17 @@ export default class CustomNode extends Components.Node {
 
   get titleBackground() {
     switch (this.data.type) {
-      case Nodes.Conv1d:
-      case Nodes.Conv2d:
-      case Nodes.Conv3d:
+      case ModelNodes.Conv1d:
+      case ModelNodes.Conv2d:
+      case ModelNodes.Conv3d:
         return { background: 'var(--blue)' };
-      case Nodes.MaxPool2d:
+      case ModelNodes.MaxPool2d:
         return { background: 'var(--red)' };
-      case Nodes.Dropout:
+      case ModelNodes.Dropout:
         return { background: 'var(--pink)' };
-      case Nodes.Flatten:
+      case ModelNodes.Flatten:
         return { background: 'var(--green)' };
-      case Nodes.Custom:
+      case CommonNodes.Custom:
         return { background: 'var(--purple)' };
       default:
         return { background: 'var(--black)' };

--- a/src/baklava/options/CodeVaultButton.vue
+++ b/src/baklava/options/CodeVaultButton.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { Mutation } from 'vuex-class';
-import Custom from '@/nodes/model/custom/Custom';
+import Custom from '@/nodes/common/Custom';
 import UIButton from '@/components/buttons/UIButton.vue';
 
 @Component({

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -14,7 +14,9 @@
       </Tab>
     </Tabs>
     <Tabs v-show="currEditorType === editorType.DATA">
-      <Tab name="Data Stuff"/>
+      <Tab name="Data Components">
+        <DataComponentsTab/>
+      </Tab>
     </Tabs>
   </div>
 </template>
@@ -28,9 +30,11 @@ import SearchTab from '@/components/tabs/SearchTab.vue';
 import EditorType from '@/EditorType';
 import ComponentsTab from '@/components/tabs/ComponentsTab.vue';
 import { mapGetters } from 'vuex';
+import DataComponentsTab from '@/components/tabs/DataComponentsTab.vue';
 
 @Component({
   components: {
+    DataComponentsTab,
     ComponentsTab,
     SearchTab,
     LayersTab,

--- a/src/components/canvas/AbstractCanvas.ts
+++ b/src/components/canvas/AbstractCanvas.ts
@@ -1,12 +1,27 @@
 import { OptionPlugin } from '@baklavajs/plugin-options-vue';
 import { Editor } from '@baklavajs/core';
+import { NodeConstructor } from '@baklavajs/core/dist/baklavajs-core/types/index.d';
 
 export default abstract class AbstractCanvas {
+  public abstract nodeList: {
+    category: string;
+    nodes: {
+      name: string;
+      node: NodeConstructor;
+    }[];
+  }[];
+
   protected option: OptionPlugin = new OptionPlugin();
 
   public get optionPlugin(): OptionPlugin {
     return this.option;
   }
 
-  public abstract registerNodes(editor: Editor): void;
+  public registerNodes(editor: Editor) {
+    this.nodeList.forEach(({ category, nodes }) => {
+      nodes.forEach(({ name, node }) => {
+        editor.registerNodeType(name, node, category);
+      });
+    });
+  }
 }

--- a/src/components/canvas/DataCanvas.ts
+++ b/src/components/canvas/DataCanvas.ts
@@ -1,8 +1,18 @@
 import AbstractCanvas from '@/components/canvas/AbstractCanvas';
-import { Editor } from '@baklavajs/core';
+import { DataCategories } from '@/nodes/data/Types';
+import { CommonNodes } from '@/nodes/common/Types';
+import Custom from '@/nodes/common/Custom';
 
 export default class DataCanvas extends AbstractCanvas {
-  registerNodes(editor: Editor): void {
-    console.log('No nodes registered');
-  }
+  public nodeList = [
+    {
+      category: DataCategories.Custom,
+      nodes: [
+        {
+          name: CommonNodes.Custom,
+          node: Custom,
+        },
+      ],
+    },
+  ];
 }

--- a/src/components/canvas/ModelCanvas.ts
+++ b/src/components/canvas/ModelCanvas.ts
@@ -1,13 +1,11 @@
 import AbstractCanvas from '@/components/canvas/AbstractCanvas';
-import { Editor } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelCategories, ModelNodes } from '@/nodes/model/Types';
 
 import Conv1d from '@/nodes/model/Conv1d';
 import Conv2d from '@/nodes/model/Conv2d';
 import Conv3d from '@/nodes/model/Conv3d';
-import Custom from '@/nodes/model/custom/Custom';
 import OutModel from '@/nodes/model/OutModel';
-import Concat from '@/nodes/model/operations/Concat';
+import Concat from '@/nodes/model/Concat';
 import InModel from '@/nodes/model/InModel';
 import Convtranspose1d from '@/nodes/model/Convtranspose1d';
 import Convtranspose2d from '@/nodes/model/Convtranspose2d';
@@ -19,41 +17,153 @@ import Dropout from '@/nodes/model/Dropout';
 import Dropout2d from '@/nodes/model/Dropout2d';
 import Dropout3d from '@/nodes/model/Dropout3d';
 import ReLU from '@/nodes/model/Relu';
-import Linear from '@/nodes/model/Linear';
+import { CommonNodes } from '@/nodes/common/Types';
+import Custom from '@/nodes/common/Custom';
 import Transformer from '@/nodes/model/Transformer';
-import Bilinear from '@/nodes/model/Bilinear';
-import Softmax from '@/nodes/model/Softmax';
 import Softmin from '@/nodes/model/Softmin';
+import Softmax from '@/nodes/model/Softmax';
+import Bilinear from '@/nodes/model/Bilinear';
+import Linear from '@/nodes/model/Linear';
 
 export default class ModelCanvas extends AbstractCanvas {
-  public registerNodes(editor: Editor): void {
-    editor.registerNodeType(Nodes.Conv1d, Conv1d, Layers.Conv);
-    editor.registerNodeType(Nodes.Conv2d, Conv2d, Layers.Conv);
-    editor.registerNodeType(Nodes.Conv3d, Conv3d, Layers.Conv);
-    editor.registerNodeType(Nodes.ConvTranspose1d, Convtranspose1d, Layers.Conv);
-    editor.registerNodeType(Nodes.ConvTranspose2d, Convtranspose2d, Layers.Conv);
-    editor.registerNodeType(Nodes.ConvTranspose3d, Convtranspose3d, Layers.Conv);
-
-    editor.registerNodeType(Nodes.MaxPool1d, Maxpool1d, Layers.Pool);
-    editor.registerNodeType(Nodes.MaxPool2d, Maxpool2d, Layers.Pool);
-    editor.registerNodeType(Nodes.MaxPool3d, Maxpool3d, Layers.Pool);
-
-    editor.registerNodeType(Nodes.Dropout, Dropout, Layers.Dropout);
-    editor.registerNodeType(Nodes.Dropout2d, Dropout2d, Layers.Dropout);
-    editor.registerNodeType(Nodes.Dropout3d, Dropout3d, Layers.Dropout);
-
-    editor.registerNodeType(Nodes.Relu, ReLU, Layers.Activation);
-
-    editor.registerNodeType(Nodes.Custom, Custom, Layers.Custom);
-    editor.registerNodeType(Nodes.InModel, InModel, Layers.IO);
-    editor.registerNodeType(Nodes.OutModel, OutModel, Layers.IO);
-    editor.registerNodeType(Nodes.Concat, Concat, Layers.Operations);
-
-    editor.registerNodeType(Nodes.Linear, Linear, Layers.Linear);
-    editor.registerNodeType(Nodes.Bilinear, Bilinear, Layers.Linear);
-
-    editor.registerNodeType(Nodes.Transformer, Transformer, Layers.Transformer);
-    editor.registerNodeType(Nodes.Softmin, Softmin, Layers.NonLinearActivation);
-    editor.registerNodeType(Nodes.Softmax, Softmax, Layers.NonLinearActivation);
-  }
+  public nodeList = [
+    {
+      category: ModelCategories.IO,
+      nodes: [
+        {
+          name: ModelNodes.InModel,
+          node: InModel,
+        },
+        {
+          name: ModelNodes.OutModel,
+          node: OutModel,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Conv,
+      nodes: [
+        {
+          name: ModelNodes.Conv1d,
+          node: Conv1d,
+        },
+        {
+          name: ModelNodes.Conv2d,
+          node: Conv2d,
+        },
+        {
+          name: ModelNodes.Conv3d,
+          node: Conv3d,
+        },
+        {
+          name: ModelNodes.ConvTranspose1d,
+          node: Convtranspose1d,
+        },
+        {
+          name: ModelNodes.ConvTranspose2d,
+          node: Convtranspose2d,
+        },
+        {
+          name: ModelNodes.ConvTranspose3d,
+          node: Convtranspose3d,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Pool,
+      nodes: [
+        {
+          name: ModelNodes.MaxPool1d,
+          node: Maxpool1d,
+        },
+        {
+          name: ModelNodes.MaxPool2d,
+          node: Maxpool2d,
+        },
+        {
+          name: ModelNodes.MaxPool3d,
+          node: Maxpool3d,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Dropout,
+      nodes: [
+        {
+          name: ModelNodes.Dropout,
+          node: Dropout,
+        },
+        {
+          name: ModelNodes.Dropout2d,
+          node: Dropout2d,
+        },
+        {
+          name: ModelNodes.Dropout3d,
+          node: Dropout3d,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Activation,
+      nodes: [
+        {
+          name: ModelNodes.Relu,
+          node: ReLU,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Custom,
+      nodes: [
+        {
+          name: CommonNodes.Custom,
+          node: Custom,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Operations,
+      nodes: [
+        {
+          name: ModelNodes.Concat,
+          node: Concat,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Linear,
+      nodes: [
+        {
+          name: ModelNodes.Linear,
+          node: Linear,
+        },
+        {
+          name: ModelNodes.Bilinear,
+          node: Bilinear,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.Transformer,
+      nodes: [
+        {
+          name: ModelNodes.Transformer,
+          node: Transformer,
+        },
+      ],
+    },
+    {
+      category: ModelCategories.NonLinearActivation,
+      nodes: [
+        {
+          name: ModelNodes.Softmin,
+          node: Softmin,
+        },
+        {
+          name: ModelNodes.Softmax,
+          node: Softmax,
+        },
+      ],
+    },
+  ];
 }

--- a/src/components/canvas/OverviewCanvas.ts
+++ b/src/components/canvas/OverviewCanvas.ts
@@ -1,10 +1,28 @@
 import AbstractCanvas from '@/components/canvas/AbstractCanvas';
-import { Editor } from '@baklavajs/core';
 import Model from '@/nodes/overview/Model';
-import { Overview } from '@/nodes/model/Types';
+import { OverviewCategories, OverviewNodes } from '@/nodes/overview/Types';
+import { CommonNodes } from '@/nodes/common/Types';
+import Custom from '@/nodes/common/Custom';
 
 export default class OverviewCanvas extends AbstractCanvas {
-  registerNodes(editor: Editor): void {
-    editor.registerNodeType(Overview.ModelNode, Model);
-  }
+  nodeList = [
+    {
+      category: OverviewCategories.Model,
+      nodes: [
+        {
+          name: OverviewNodes.ModelNode,
+          node: Model,
+        },
+      ],
+    },
+    {
+      category: OverviewCategories.Custom,
+      nodes: [
+        {
+          name: CommonNodes.Custom,
+          node: Custom,
+        },
+      ],
+    },
+  ];
 }

--- a/src/components/tabs/DataComponentsTab.vue
+++ b/src/components/tabs/DataComponentsTab.vue
@@ -1,14 +1,5 @@
 <template>
   <div>
-    <ExpandablePanel name="Models">
-      <ButtonGrid>
-        <AddNodeButton v-for="editor in modelEditors"
-                       :node="modelNodeType"
-                       :options="editor"
-                       :key="editor.name"
-                       :name="editor.name"/>
-      </ButtonGrid>
-    </ExpandablePanel>
     <ExpandablePanel name="Custom">
       <ButtonGrid>
         <AddNodeButton node="Custom" name="Custom"/>
@@ -22,8 +13,6 @@ import { Component, Vue } from 'vue-property-decorator';
 import ExpandablePanel from '@/components/ExpandablePanel.vue';
 import AddNodeButton from '@/components/buttons/AddNodeButton.vue';
 import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
-import { mapGetters } from 'vuex';
-import { OverviewNodes } from '@/nodes/overview/Types';
 
 @Component({
   components: {
@@ -31,9 +20,7 @@ import { OverviewNodes } from '@/nodes/overview/Types';
     AddNodeButton,
     ButtonGrid,
   },
-  computed: mapGetters(['modelEditors']),
 })
-export default class ComponentsTab extends Vue {
-  private modelNodeType = OverviewNodes.ModelNode;
+export default class DataComponentsTab extends Vue {
 }
 </script>

--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -66,7 +66,7 @@ import { Getter, Mutation } from 'vuex-class';
 import { ParsedFile } from '@/store/codeVault/types';
 import { uniqueTextInput } from '@/inputs/prompt';
 import FileFuncButton from '@/components/buttons/FileFuncButton.vue';
-import Custom from '@/nodes/model/custom/Custom';
+import Custom from '@/nodes/common/Custom';
 
 @Component({
   components: {

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -20,7 +20,7 @@ import Ace from 'brace';
 import 'brace/mode/python';
 import '@/assets/ivann-theme';
 import { Getter, Mutation } from 'vuex-class';
-import Custom from '@/nodes/model/custom/Custom';
+import Custom from '@/nodes/common/Custom';
 import UIButton from '@/components/buttons/UIButton.vue';
 import parse from '@/app/parser/parser';
 import ParsedFunction from '@/app/parser/ParsedFunction';

--- a/src/components/tabs/LayersTab.vue
+++ b/src/components/tabs/LayersTab.vue
@@ -1,77 +1,26 @@
 <template>
   <div class="layers-tab">
-    <ExpandablePanel name="I/O">
+    <ExpandablePanel v-for="(category) in modelNodes" :key="category.category"
+                     :name="category.category">
       <ButtonGrid>
-        <AddNodeButton node="InModel" name="Input" :names="editorIONames"/>
-        <AddNodeButton node="OutModel" name="Output" :names="editorIONames"/>
+        <AddNodeButton v-for="(node) in category.nodes" :key="node.name"
+                       :node="node.name"
+                       :name="node.name"
+                       :names="node.name === 'InModel' || node.name === 'OutModel'
+                        ? editorIONames : undefined"
+        />
       </ButtonGrid>
     </ExpandablePanel>
-    <ExpandablePanel name="Convolutional">
-      <ButtonGrid>
-        <AddNodeButton node="Conv1d" name="Conv1d"/>
-        <AddNodeButton node="Conv2d" name="Conv2d"/>
-        <AddNodeButton node="Conv3d" name="Conv3d"/>
-        <AddNodeButton node="ConvTranspose1d" name="ConvTranspose1d"/>
-        <AddNodeButton node="ConvTranspose2d" name="ConvTranspose2d"/>
-        <AddNodeButton node="ConvTranspose3d" name="ConvTranspose3d"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Pooling">
-      <ButtonGrid>
-        <AddNodeButton node="MaxPool1d" name="MaxPool1d"/>
-        <AddNodeButton node="MaxPool2d" name="MaxPool2d"/>
-        <AddNodeButton node="MaxPool3d" name="MaxPool3d"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Regularization">
-      <ButtonGrid>
-        <AddNodeButton node="Dropout" name="Dropout"/>
-        <AddNodeButton node="Dropout2d" name="Dropout2d"/>
-        <AddNodeButton node="Dropout3d" name="Dropout3d"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Activation Functions">
-      <ButtonGrid>
-        <AddNodeButton node="Relu" name="Relu"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Custom">
-      <ButtonGrid>
-        <AddNodeButton node="Custom" name="Custom"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Operations">
-      <ButtonGrid>
-        <AddNodeButton node="Concat" name="Concat"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Linear">
-      <ButtonGrid>
-        <AddNodeButton node="Linear" name="Linear"/>
-        <AddNodeButton node="Bilinear" name="Bilinear"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Transformer">
-      <ButtonGrid>
-        <AddNodeButton node="Transformer" name="Transformer"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Non-Linear Activation">
-      <ButtonGrid>
-        <AddNodeButton node="Softmin" name="Softmin"/>
-        <AddNodeButton node="Softmax" name="Softmax"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import ExpandablePanel from '@/components/ExpandablePanel.vue';
 import AddNodeButton from '@/components/buttons/AddNodeButton.vue';
 import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
 import { mapGetters } from 'vuex';
+import EditorManager from '@/EditorManager';
 
 @Component({
   components: {
@@ -82,5 +31,6 @@ import { mapGetters } from 'vuex';
   computed: mapGetters(['editorIONames']),
 })
 export default class LayersTab extends Vue {
+  private modelNodes = EditorManager.getInstance().modelCanvas.nodeList;
 }
 </script>

--- a/src/nodes/common/Custom.ts
+++ b/src/nodes/common/Custom.ts
@@ -1,15 +1,15 @@
 import { Node } from '@baklavajs/core';
-import { Nodes } from '@/nodes/model/Types';
 import { INodeState } from '@baklavajs/core/dist/baklavajs-core/types/state.d';
 import ParsedFunction from '@/app/parser/ParsedFunction';
+import { CommonNodes } from '@/nodes/common/Types';
 
 // TODO CORE-58 Change InlineCode Option to use state.parsedFunction
 export enum CustomOptions {
   InlineCode = 'Inline Code',
 }
 export default class Custom extends Node {
-  type = Nodes.Custom;
-  name: string = Nodes.Custom;
+  type = CommonNodes.Custom;
+  name: string = CommonNodes.Custom;
 
   private inputNames: string[] = [];
 
@@ -48,7 +48,7 @@ export default class Custom extends Node {
   private updateNode() {
     const parsedFunction = this.getParsedFunction();
     if (!parsedFunction) {
-      this.name = Nodes.Custom;
+      this.name = CommonNodes.Custom;
       this.removeAllInputs();
       this.removeOutput();
     } else {

--- a/src/nodes/common/Types.ts
+++ b/src/nodes/common/Types.ts
@@ -1,0 +1,3 @@
+export const enum CommonNodes {
+  Custom = 'Custom',
+}

--- a/src/nodes/data/Types.ts
+++ b/src/nodes/data/Types.ts
@@ -1,0 +1,3 @@
+export const enum DataCategories {
+  Custom = 'Custom',
+}

--- a/src/nodes/model/Bilinear.ts
+++ b/src/nodes/model/Bilinear.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 
@@ -10,8 +10,8 @@ export enum BilinearOptions {
   Bias = 'Bias'
 }
 export default class Bilinear extends Node {
-  type = Nodes.Bilinear;
-  name = Nodes.Bilinear;
+  type = ModelNodes.Bilinear;
+  name = ModelNodes.Bilinear;
 
   constructor() {
     super();

--- a/src/nodes/model/Concat.ts
+++ b/src/nodes/model/Concat.ts
@@ -1,9 +1,9 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 
 export default class Concat extends Node {
-  type = Nodes.Concat;
-  name = Nodes.Concat;
+  type = ModelNodes.Concat;
+  name = ModelNodes.Concat;
 
   constructor() {
     super();

--- a/src/nodes/model/Conv1d.ts
+++ b/src/nodes/model/Conv1d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -18,8 +18,8 @@ export enum Conv1dOptions {
 }
 
 export default class Conv1d extends Node {
-  type = Nodes.Conv1d;
-  name = Nodes.Conv1d;
+  type = ModelNodes.Conv1d;
+  name = ModelNodes.Conv1d;
 
   constructor() {
     super();

--- a/src/nodes/model/Conv2d.ts
+++ b/src/nodes/model/Conv2d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -17,8 +17,8 @@ export enum Conv2dOptions {
   PaddingMode = 'Padding mode'
 }
 export default class Conv2d extends Node {
-  type = Nodes.Conv2d;
-  name = Nodes.Conv2d;
+  type = ModelNodes.Conv2d;
+  name = ModelNodes.Conv2d;
 
   constructor() {
     super();

--- a/src/nodes/model/Conv3d.ts
+++ b/src/nodes/model/Conv3d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -17,8 +17,8 @@ export enum Conv3dOptions {
   PaddingMode = 'Padding mode'
 }
 export default class Conv3d extends Node {
-  type = Nodes.Conv3d;
-  name = Nodes.Conv3d;
+  type = ModelNodes.Conv3d;
+  name = ModelNodes.Conv3d;
 
   constructor() {
     super();

--- a/src/nodes/model/Convtranspose1d.ts
+++ b/src/nodes/model/Convtranspose1d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -18,8 +18,8 @@ export enum ConvTranspose1dOptions {
   PaddingMode = 'Padding mode'
 }
 export default class ConvTranspose1d extends Node {
-  type = Nodes.ConvTranspose1d;
-  name = Nodes.ConvTranspose1d;
+  type = ModelNodes.ConvTranspose1d;
+  name = ModelNodes.ConvTranspose1d;
 
   constructor() {
     super();

--- a/src/nodes/model/Convtranspose2d.ts
+++ b/src/nodes/model/Convtranspose2d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -18,8 +18,8 @@ export enum ConvTranspose2dOptions {
   PaddingMode = 'Padding mode'
 }
 export default class ConvTranspose2d extends Node {
-  type = Nodes.ConvTranspose2d;
-  name = Nodes.ConvTranspose2d;
+  type = ModelNodes.ConvTranspose2d;
+  name = ModelNodes.ConvTranspose2d;
 
   constructor() {
     super();

--- a/src/nodes/model/Convtranspose3d.ts
+++ b/src/nodes/model/Convtranspose3d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 import { valuesOf } from '@/app/util';
@@ -18,8 +18,8 @@ export enum ConvTranspose3dOptions {
   PaddingMode = 'Padding mode'
 }
 export default class ConvTranspose3d extends Node {
-  type = Nodes.ConvTranspose3d;
-  name = Nodes.ConvTranspose3d;
+  type = ModelNodes.ConvTranspose3d;
+  name = ModelNodes.ConvTranspose3d;
 
   constructor() {
     super();

--- a/src/nodes/model/Dropout.ts
+++ b/src/nodes/model/Dropout.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum DropoutOptions {
@@ -7,8 +7,8 @@ export enum DropoutOptions {
   Inplace = 'Inplace'
 }
 export default class Dropout extends Node {
-  type = Nodes.Dropout;
-  name = Nodes.Dropout;
+  type = ModelNodes.Dropout;
+  name = ModelNodes.Dropout;
 
   constructor() {
     super();

--- a/src/nodes/model/Dropout2d.ts
+++ b/src/nodes/model/Dropout2d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum Dropout2dOptions {
@@ -7,8 +7,8 @@ export enum Dropout2dOptions {
   Inplace = 'Inplace'
 }
 export default class Dropout2d extends Node {
-  type = Nodes.Dropout2d;
-  name = Nodes.Dropout2d;
+  type = ModelNodes.Dropout2d;
+  name = ModelNodes.Dropout2d;
 
   constructor() {
     super();

--- a/src/nodes/model/Dropout3d.ts
+++ b/src/nodes/model/Dropout3d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum Dropout3dOptions {
@@ -7,8 +7,8 @@ export enum Dropout3dOptions {
   Inplace = 'Inplace'
 }
 export default class Dropout3d extends Node {
-  type = Nodes.Dropout3d;// TODO add layer type
-  name = Nodes.Dropout3d;
+  type = ModelNodes.Dropout3d;// TODO add layer type
+  name = ModelNodes.Dropout3d;
 
   constructor() {
     super();

--- a/src/nodes/model/InModel.ts
+++ b/src/nodes/model/InModel.ts
@@ -1,9 +1,9 @@
 import { Node } from '@baklavajs/core';
-import { Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 
 export default class InModel extends Node {
-  type = Nodes.InModel;
-  name = Nodes.InModel;
+  type = ModelNodes.InModel;
+  name = ModelNodes.InModel;
 
   constructor() {
     super();

--- a/src/nodes/model/Linear.ts
+++ b/src/nodes/model/Linear.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 import CheckboxValue from '@/baklava/CheckboxValue';
 
@@ -9,8 +9,8 @@ export enum LinearOptions {
   Bias = 'Bias'
 }
 export default class Linear extends Node {
-  type = Nodes.Linear;
-  name = Nodes.Linear;
+  type = ModelNodes.Linear;
+  name = ModelNodes.Linear;
 
   constructor() {
     super();

--- a/src/nodes/model/Maxpool1d.ts
+++ b/src/nodes/model/Maxpool1d.ts
@@ -1,7 +1,6 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
-import { Conv1dOptions } from '@/nodes/model/Conv1d';
 
 export enum MaxPool1dOptions {
   KernelSize = 'Kernel size',
@@ -12,8 +11,8 @@ export enum MaxPool1dOptions {
   CeilMode = 'Ceil mode'
 }
 export default class MaxPool1d extends Node {
-  type = Nodes.MaxPool1d;
-  name = Nodes.MaxPool1d;
+  type = ModelNodes.MaxPool1d;
+  name = ModelNodes.MaxPool1d;
 
   constructor() {
     super();

--- a/src/nodes/model/Maxpool2d.ts
+++ b/src/nodes/model/Maxpool2d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum MaxPool2dOptions {
@@ -11,8 +11,8 @@ export enum MaxPool2dOptions {
   CeilMode = 'Ceil mode'
 }
 export default class MaxPool2d extends Node {
-  type = Nodes.MaxPool2d;
-  name = Nodes.MaxPool2d;
+  type = ModelNodes.MaxPool2d;
+  name = ModelNodes.MaxPool2d;
 
   constructor() {
     super();

--- a/src/nodes/model/Maxpool3d.ts
+++ b/src/nodes/model/Maxpool3d.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum MaxPool3dOptions {
@@ -11,8 +11,8 @@ export enum MaxPool3dOptions {
   CeilMode = 'Ceil mode'
 }
 export default class MaxPool3d extends Node {
-  type = Nodes.MaxPool3d;
-  name = Nodes.MaxPool3d;
+  type = ModelNodes.MaxPool3d;
+  name = ModelNodes.MaxPool3d;
 
   constructor() {
     super();

--- a/src/nodes/model/OutModel.ts
+++ b/src/nodes/model/OutModel.ts
@@ -1,9 +1,9 @@
 import { Node } from '@baklavajs/core';
-import { Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 
 export default class OutModel extends Node {
-  type = Nodes.OutModel;
-  name = Nodes.OutModel;
+  type = ModelNodes.OutModel;
+  name = ModelNodes.OutModel;
 
   constructor() {
     super();

--- a/src/nodes/model/Relu.ts
+++ b/src/nodes/model/Relu.ts
@@ -1,13 +1,13 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum ReLUOptions {
   Inplace = 'Inplace'
 }
 export default class ReLU extends Node {
-  type = Nodes.Relu;
-  name = Nodes.Relu;
+  type = ModelNodes.Relu;
+  name = ModelNodes.Relu;
 
   constructor() {
     super();

--- a/src/nodes/model/Softmax.ts
+++ b/src/nodes/model/Softmax.ts
@@ -1,13 +1,13 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum SoftmaxOptions {
   Dim = 'Dim'
 }
 export default class Softmax extends Node {
-  type = Nodes.Softmax;
-  name = Nodes.Softmax;
+  type = ModelNodes.Softmax;
+  name = ModelNodes.Softmax;
 
   constructor() {
     super();

--- a/src/nodes/model/Softmin.ts
+++ b/src/nodes/model/Softmin.ts
@@ -1,13 +1,13 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum SoftminOptions {
   Dim = 'Dim'
 }
 export default class Softmin extends Node {
-  type = Nodes.Softmin;
-  name = Nodes.Softmin;
+  type = ModelNodes.Softmin;
+  name = ModelNodes.Softmin;
 
   constructor() {
     super();

--- a/src/nodes/model/Transformer.ts
+++ b/src/nodes/model/Transformer.ts
@@ -1,5 +1,5 @@
 import { Node } from '@baklavajs/core';
-import { Layers, Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
 
 export enum TransformerOptions {
@@ -14,8 +14,8 @@ export enum TransformerOptions {
   CustomDecoder = 'Custom decoder'
 }
 export default class Transformer extends Node {
-  type = Nodes.Transformer;
-  name = Nodes.Transformer;
+  type = ModelNodes.Transformer;
+  name = ModelNodes.Transformer;
 
   constructor() {
     super();

--- a/src/nodes/model/Types.ts
+++ b/src/nodes/model/Types.ts
@@ -1,23 +1,19 @@
-export const enum Layers {
+export const enum ModelCategories {
   Linear = 'Linear',
   Conv = 'Convolution',
   Pool = 'Pooling',
   Dropout = 'Dropout',
   Regularization = 'Regularization',
   Reshape = 'Reshaping',
-  Activation = 'Activation functions',
+  Activation = 'Activation Functions',
   Custom = 'Custom',
   Operations = 'Operations',
   IO = 'I/O',
   Transformer = 'Transformer',
-  NonLinearActivation = 'Non-Linear ACtivation'
+  NonLinearActivation = 'Non-Linear Activation'
 }
 
-export const enum Overview {
-  ModelNode = 'ModelNode',
-}
-
-export const enum Nodes {
+export const enum ModelNodes {
   Conv1d = 'Conv1d',
   Conv2d = 'Conv2d',
   Conv3d = 'Conv3d',
@@ -33,7 +29,6 @@ export const enum Nodes {
   Relu = 'Relu',
   Softmax = 'Softmax',
   Flatten = 'Flatten',
-  Custom = 'Custom',
   Concat = 'Concat',
   InModel = 'InModel',
   OutModel = 'OutModel',

--- a/src/nodes/overview/Model.ts
+++ b/src/nodes/overview/Model.ts
@@ -1,13 +1,13 @@
 import { Node } from '@baklavajs/core';
-import { Overview } from '@/nodes/model/Types';
 import { EditorModel } from '@/store/editors/types';
 import { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
 import { getEditorIOs } from '@/store/editors/utils';
 import { INodeState } from '@baklavajs/core/dist/baklavajs-core/types/state.d';
+import { OverviewNodes } from '@/nodes/overview/Types';
 
 export default class Model extends Node {
   name = '';
-  type = Overview.ModelNode;
+  type = OverviewNodes.ModelNode;
 
   constructor(model?: EditorModel) {
     super();

--- a/src/nodes/overview/Types.ts
+++ b/src/nodes/overview/Types.ts
@@ -1,0 +1,8 @@
+export const enum OverviewCategories {
+  Model = 'Model',
+  Custom = 'Custom',
+}
+
+export const enum OverviewNodes {
+  ModelNode = 'ModelNode',
+}

--- a/src/store/codeVault/mutations.ts
+++ b/src/store/codeVault/mutations.ts
@@ -1,7 +1,7 @@
 import { MutationTree } from 'vuex';
 import { CodeVaultState, ParsedFile } from '@/store/codeVault/types';
 import ParsedFunction from '@/app/parser/ParsedFunction';
-import Custom from '@/nodes/model/custom/Custom';
+import Custom from '@/nodes/common/Custom';
 
 const codeVaultMutations: MutationTree<CodeVaultState> = {
   resetState(state) {

--- a/src/store/codeVault/types.ts
+++ b/src/store/codeVault/types.ts
@@ -1,5 +1,5 @@
 import ParsedFunction from '@/app/parser/ParsedFunction';
-import Custom from '@/nodes/model/custom/Custom';
+import Custom from '@/nodes/common/Custom';
 
 export interface ParsedFile {
   filename: string;

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -2,7 +2,7 @@ import { GetterTree } from 'vuex';
 import { RootState } from '@/store/types';
 import { EditorModels, EditorsState } from '@/store/editors/types';
 import EditorType from '@/EditorType';
-import { Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 import { SaveWithNames } from '@/file/EditorAsJson';
 
 const editorGetters: GetterTree<EditorsState, RootState> = {
@@ -47,7 +47,7 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
   editorIONames: (state, getters) => {
     const names: Set<string> = new Set<string>();
     for (const node of getters.currEditorModel.editor.nodes) {
-      if (node.type === Nodes.InModel || node.type === Nodes.OutModel) {
+      if (node.type === ModelNodes.InModel || node.type === ModelNodes.OutModel) {
         names.add(node.name);
       }
     }

--- a/src/store/editors/utils.ts
+++ b/src/store/editors/utils.ts
@@ -1,15 +1,15 @@
 import { EditorModel } from '@/store/editors/types';
-import { Nodes } from '@/nodes/model/Types';
+import { ModelNodes } from '@/nodes/model/Types';
 
 export function getEditorIOs(editorModel: EditorModel): { inputs: string[]; outputs: string[] } {
   const inputs: string[] = [];
   const outputs: string[] = [];
   for (const node of editorModel.editor.nodes) {
     switch (node.type) {
-      case Nodes.InModel:
+      case ModelNodes.InModel:
         inputs.push(node.name);
         break;
-      case Nodes.OutModel:
+      case ModelNodes.OutModel:
         outputs.push(node.name);
         break;
       default:


### PR DESCRIPTION
This PR adds the Custom Node in the Overview Editor and the Data Editor.

Additionally, I did quite a big refactor that allows Registering Nodes automatically in classes extended `AbstractCanvas`. I did this because there seemed to be quite some code duplication between the Layers Tab and the Model Canvas. If you don't like it or feel it's overkill, I can remove it so please tell me! 🙂 