### PR TITLE
FE-83 Add Auto-Save and Auto-Load for Code Vault files and functions

### DIFF
--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -72,7 +72,7 @@ import parse from '@/app/parser/parser';
 import ParsedFunction from '@/app/parser/ParsedFunction';
 import { Result } from '@/app/util';
 import { Getter, Mutation } from 'vuex-class';
-import { CodeVaultSaveWithNames, ParsedFile } from '@/store/codeVault/types';
+import { FilenamesList, ParsedFile } from '@/store/codeVault/types';
 import { uniqueTextInput } from '@/inputs/prompt';
 import FileFuncButton from '@/components/buttons/FileFuncButton.vue';
 import Custom from '@/nodes/common/Custom';
@@ -96,7 +96,7 @@ export default class FunctionsTab extends Vue {
   @Getter('fileIndexFromFilename') fileIndexFromFilename!: (filename: string) => number;
   @Getter('functionIndexFromFunctionName') functionIndexFromFunctionName!:
     (fileIndex: number, functionName: string) => number;
-  @Getter('codeVaultSaveWithNames') codeVaultSaveWithNames!: CodeVaultSaveWithNames;
+  @Getter('filenamesList') filenamesList!: FilenamesList;
 
   private selectedFile = -1;
   private selectedFunction = -1;
@@ -170,8 +170,9 @@ export default class FunctionsTab extends Vue {
       if (parsed instanceof Error) {
         console.error(parsed);
       } else {
-        this.addFile({ filename: files[0].name, functions: parsed });
-        this.saveToCookies(files[0].name, parsed);
+        const file = { filename: files[0].name, functions: parsed };
+        this.addFile(file);
+        this.saveToCookies(file);
       }
     };
 
@@ -185,7 +186,9 @@ export default class FunctionsTab extends Vue {
     );
     if (name === null) return;
 
-    this.addFile({ filename: `${name}.py`, functions: [] });
+    const file = { filename: `${name}.py`, functions: [] };
+    this.addFile(file);
+    this.saveToCookies(file);
   }
 
   // Disable buttons when got here through navbar and not custom node
@@ -211,11 +214,9 @@ export default class FunctionsTab extends Vue {
     this.leaveCodeVault();
   }
 
-  private saveToCookies(filename: string, functions: ParsedFunction[]) {
-    this.$cookies.set('unsaved-code-vault', this.codeVaultSaveWithNames);
-    functions.forEach((func) => {
-      this.$cookies.set(`unsaved-function-${filename}-${func.name}`, JSON.stringify(func));
-    });
+  private saveToCookies(file: ParsedFile) {
+    this.$cookies.set('unsaved-code-vault', this.filenamesList);
+    this.$cookies.set(`unsaved-file-${file.filename}`, file);
   }
 }
 </script>

--- a/src/store/codeVault/getters.ts
+++ b/src/store/codeVault/getters.ts
@@ -1,6 +1,6 @@
 import { GetterTree } from 'vuex';
 import { RootState } from '@/store/types';
-import { CodeVaultSaveWithNames, CodeVaultState } from '@/store/codeVault/types';
+import { CodeVaultState, FilenamesList } from '@/store/codeVault/types';
 
 const codeVaultGetters: GetterTree<CodeVaultState, RootState> = {
   files: (state) => state.files,
@@ -15,11 +15,8 @@ const codeVaultGetters: GetterTree<CodeVaultState, RootState> = {
     .files.findIndex((file) => file.filename === filename),
   functionIndexFromFunctionName: (state) => (fileIndex: number, functionName: string) => state
     .files[fileIndex].functions.findIndex((func) => func.name === functionName),
-  codeVaultSaveWithNames: (state): CodeVaultSaveWithNames => ({
-    files: state.files.map((file) => ({
-      filename: file.filename,
-      functionNames: file.functions.map((func) => func.name),
-    })),
+  filenamesList: (state): FilenamesList => ({
+    filenames: state.files.map((file) => file.filename),
   }),
 };
 

--- a/src/store/codeVault/getters.ts
+++ b/src/store/codeVault/getters.ts
@@ -1,6 +1,6 @@
 import { GetterTree } from 'vuex';
 import { RootState } from '@/store/types';
-import { CodeVaultState } from '@/store/codeVault/types';
+import { CodeVaultSaveWithNames, CodeVaultState } from '@/store/codeVault/types';
 
 const codeVaultGetters: GetterTree<CodeVaultState, RootState> = {
   files: (state) => state.files,
@@ -15,6 +15,12 @@ const codeVaultGetters: GetterTree<CodeVaultState, RootState> = {
     .files.findIndex((file) => file.filename === filename),
   functionIndexFromFunctionName: (state) => (fileIndex: number, functionName: string) => state
     .files[fileIndex].functions.findIndex((func) => func.name === functionName),
+  codeVaultSaveWithNames: (state): CodeVaultSaveWithNames => ({
+    files: state.files.map((file) => ({
+      filename: file.filename,
+      functionNames: file.functions.map((func) => func.name),
+    })),
+  }),
 };
 
 export default codeVaultGetters;

--- a/src/store/codeVault/types.ts
+++ b/src/store/codeVault/types.ts
@@ -10,3 +10,12 @@ export interface CodeVaultState {
   files: ParsedFile[];
   nodeTriggeringCodeVault?: Custom;
 }
+
+export interface CodeVaultSaveWithNames {
+  files: FileSaveWithNames[];
+}
+
+export interface FileSaveWithNames {
+  filename: string;
+  functionNames: string[];
+}

--- a/src/store/codeVault/types.ts
+++ b/src/store/codeVault/types.ts
@@ -11,11 +11,6 @@ export interface CodeVaultState {
   nodeTriggeringCodeVault?: Custom;
 }
 
-export interface CodeVaultSaveWithNames {
-  files: FileSaveWithNames[];
-}
-
-export interface FileSaveWithNames {
-  filename: string;
-  functionNames: string[];
+export interface FilenamesList {
+  filenames: string[];
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,7 +24,7 @@ import { Save, saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 import EditorManager from '@/EditorManager';
 import { EditorModel } from '@/store/editors/types';
 import CodeVault from '@/components/CodeVault.vue';
-import { CodeVaultSaveWithNames, ParsedFile } from '@/store/codeVault/types';
+import { ParsedFile } from '@/store/codeVault/types';
 
 @Component({
   components: {
@@ -58,12 +58,8 @@ export default class Home extends Vue {
 
       // Auto-Load Code Vault
       if (this.$cookies.isKey('unsaved-code-vault')) {
-        const codeVaultSaveWithNames = this.$cookies.get('unsaved-code-vault') as CodeVaultSaveWithNames;
-        const files: ParsedFile[] = codeVaultSaveWithNames.files.map((file) => ({
-          filename: file.filename,
-          functions: file.functionNames
-            .map((functionName) => this.$cookies.get(`unsaved-function-${file.filename}-${functionName}`)),
-        }));
+        const filenamesList = this.$cookies.get('unsaved-code-vault');
+        const files = filenamesList.filenames.map((filename: string) => this.$cookies.get(`unsaved-file-${filename}`));
         this.loadFiles(files);
       }
     }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,6 +24,7 @@ import { Save, saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 import EditorManager from '@/EditorManager';
 import { EditorModel } from '@/store/editors/types';
 import CodeVault from '@/components/CodeVault.vue';
+import { CodeVaultSaveWithNames, ParsedFile } from '@/store/codeVault/types';
 
 @Component({
   components: {
@@ -40,6 +41,7 @@ export default class Home extends Vue {
   @Getter('saveWithNames') saveWithNames!: SaveWithNames;
   @Mutation('loadEditors') loadEditors!: (save: Save) => void;
   @Mutation('updateNodeInOverview') readonly updateNodeInOverview!: (cEditor: EditorModel) => void;
+  @Mutation('loadFiles') loadFiles!: (files: ParsedFile[]) => void;
 
   created() {
     // Auto-loading
@@ -53,6 +55,17 @@ export default class Home extends Vue {
       });
       // We reset the view to set the panning and scaling on the current view.
       EditorManager.getInstance().resetView();
+
+      // Auto-Load Code Vault
+      if (this.$cookies.isKey('unsaved-code-vault')) {
+        const codeVaultSaveWithNames = this.$cookies.get('unsaved-code-vault') as CodeVaultSaveWithNames;
+        const files: ParsedFile[] = codeVaultSaveWithNames.files.map((file) => ({
+          filename: file.filename,
+          functions: file.functionNames
+            .map((functionName) => this.$cookies.get(`unsaved-function-${file.filename}-${functionName}`)),
+        }));
+        this.loadFiles(files);
+      }
     }
 
     // Set up auto-save every 5 seconds


### PR DESCRIPTION
I decided to follow the same pattern as Editor Cookie Saving, and save one overview cookie and one cookie per file in order to limit the size of each cookie.