### PR TITLE
Disable renaming of custom nodes

### DIFF
--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -125,7 +125,7 @@ export default class CustomNode extends Components.Node {
 
   private getContextualMenuItems() {
     const items = [{ value: 'delete', label: 'Delete' }];
-    if (this.data.type !== OverviewNodes.ModelNode) {
+    if (this.data.type !== OverviewNodes.ModelNode && this.data.type !== CommonNodes.Custom) {
       items.unshift({ value: 'rename', label: 'Rename' });
     }
     return items;


### PR DESCRIPTION
Since custom nodes take the name of the function, you should not be able to rename them