### PR TITLE
FE-87 Implemented node Colours, set names of IO nodes and ordered correctly

### DIFF
--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -115,12 +115,13 @@ import { Getter } from 'vuex-class';
 import { Severity } from '@/app/ir/checking/severity';
 import { OverviewNodes } from '@/nodes/overview/Types';
 import { CommonNodes } from '@/nodes/common/Types';
+import { DataNodes } from '@/nodes/data/Types';
 
 @Component({
   components: { ArrowButton },
 })
 export default class CustomNode extends Components.Node {
-  @Getter('errorsMap') errorsMap!: Map<string, IrError[]>
+  @Getter('errorsMap') errorsMap!: Map<string, IrError[]>;
   private shouldShowOptions = false;
 
   contextMenu = {
@@ -130,12 +131,14 @@ export default class CustomNode extends Components.Node {
     items: this.getContextualMenuItems(),
   };
 
-  private currentErrors: IrError[] = []
+  private currentErrors: IrError[] = [];
+
   get messages(): string | undefined {
     return this.currentErrors.length !== 0
       ? this.currentErrors.map((e) => e.formattedMessage).reduce((prev, curr) => `${prev}\n${curr}`)
       : undefined;
   }
+
   get severity(): Severity[] {
     const index = (s: Severity) => Object.keys(Severity).indexOf(s);
     return this.currentErrors.map((e) => e.severity).sort((a, b) => index(a) - index(b));
@@ -188,15 +191,38 @@ export default class CustomNode extends Components.Node {
       case ModelNodes.Conv1d:
       case ModelNodes.Conv2d:
       case ModelNodes.Conv3d:
+      case ModelNodes.ConvTranspose1d:
+      case ModelNodes.ConvTranspose2d:
+      case ModelNodes.ConvTranspose3d:
+      case OverviewNodes.ModelNode:
+      case DataNodes.ToTensor:
+      case DataNodes.Grayscale:
         return { background: 'var(--blue)' };
+      case ModelNodes.MaxPool1d:
       case ModelNodes.MaxPool2d:
+      case ModelNodes.MaxPool3d:
         return { background: 'var(--red)' };
       case ModelNodes.Dropout:
+      case ModelNodes.Dropout2d:
+      case ModelNodes.Dropout3d:
+      case OverviewNodes.DataNode:
         return { background: 'var(--pink)' };
-      case ModelNodes.Flatten:
+      case ModelNodes.Relu:
+      case ModelNodes.Softmax:
+      case ModelNodes.Softmin:
         return { background: 'var(--green)' };
-      case CommonNodes.Custom:
+      case ModelNodes.InModel:
+      case ModelNodes.OutModel:
+      case DataNodes.InData:
+      case DataNodes.OutData:
         return { background: 'var(--purple)' };
+      case ModelNodes.Linear:
+      case ModelNodes.Bilinear:
+        return { background: 'var(--mustard)' };
+      case ModelNodes.Transformer:
+        return { background: 'var(--seafoam)' };
+      case CommonNodes.Custom:
+        return { background: 'var(--foreground)', color: 'var(--dark-grey)' };
       default:
         return { background: 'var(--black)' };
     }

--- a/src/components/canvas/DataCanvas.ts
+++ b/src/components/canvas/DataCanvas.ts
@@ -12,15 +12,6 @@ import Grayscale from '@/nodes/data/Grayscale';
 export default class DataCanvas extends AbstractCanvas {
   public nodeList = [
     {
-      category: DataCategories.Custom,
-      nodes: [
-        {
-          name: CommonNodes.Custom,
-          node: Custom,
-        },
-      ],
-    },
-    {
       category: DataCategories.IO,
       nodes: [
         {
@@ -43,6 +34,15 @@ export default class DataCanvas extends AbstractCanvas {
         {
           name: DataNodes.Grayscale,
           node: Grayscale,
+        },
+      ],
+    },
+    {
+      category: DataCategories.Custom,
+      nodes: [
+        {
+          name: CommonNodes.Custom,
+          node: Custom,
         },
       ],
     },

--- a/src/components/tabs/DataComponentsTab.vue
+++ b/src/components/tabs/DataComponentsTab.vue
@@ -1,20 +1,18 @@
 <template>
   <div>
-    <ExpandablePanel name="Custom">
+    <ExpandablePanel :name="ioLabel">
       <ButtonGrid>
-        <AddNodeButton node="Custom" name="Custom"/>
+        <AddNodeButton :node="ioNodes.nodes[0].name" name="Input" :names="editorIONames"/>
+        <AddNodeButton :node="ioNodes.nodes[1].name" name="Output"/>
       </ButtonGrid>
     </ExpandablePanel>
-    <ExpandablePanel name="I/O">
+    <ExpandablePanel v-for="(category) in dataNodes.slice(1)" :key="category.category"
+                     :name="category.category">
       <ButtonGrid>
-        <AddNodeButton node="InData" name="InData"/>
-        <AddNodeButton node="OutData" name="OutData"/>
-      </ButtonGrid>
-    </ExpandablePanel>
-    <ExpandablePanel name="Transform">
-      <ButtonGrid>
-        <AddNodeButton node="ToTensor" name="ToTensor"/>
-        <AddNodeButton node="Grayscale" name="Grayscale"/>
+        <AddNodeButton v-for="(node) in category.nodes" :key="node.name"
+                       :node="node.name"
+                       :name="node.name"
+        />
       </ButtonGrid>
     </ExpandablePanel>
   </div>
@@ -25,6 +23,9 @@ import { Component, Vue } from 'vue-property-decorator';
 import ExpandablePanel from '@/components/ExpandablePanel.vue';
 import AddNodeButton from '@/components/buttons/AddNodeButton.vue';
 import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
+import EditorManager from '@/EditorManager';
+import { DataCategories } from '@/nodes/data/Types';
+import { mapGetters } from 'vuex';
 
 @Component({
   components: {
@@ -32,7 +33,11 @@ import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
     AddNodeButton,
     ButtonGrid,
   },
+  computed: mapGetters(['editorIONames']),
 })
 export default class DataComponentsTab extends Vue {
+  private dataNodes = EditorManager.getInstance().dataCanvas.nodeList;
+  private ioNodes = this.dataNodes[0];
+  private ioLabel = DataCategories.IO;
 }
 </script>

--- a/src/components/tabs/LayersTab.vue
+++ b/src/components/tabs/LayersTab.vue
@@ -1,13 +1,17 @@
 <template>
-  <div class="layers-tab">
-    <ExpandablePanel v-for="(category) in modelNodes" :key="category.category"
+  <div>
+    <ExpandablePanel :name="ioLabel">
+      <ButtonGrid>
+        <AddNodeButton :node="ioNodes.nodes[0].name" name="Input" :names="editorIONames"/>
+        <AddNodeButton :node="ioNodes.nodes[1].name" name="Output" :names="editorIONames"/>
+      </ButtonGrid>
+    </ExpandablePanel>
+    <ExpandablePanel v-for="(category) in modelNodes.slice(1)" :key="category.category"
                      :name="category.category">
       <ButtonGrid>
         <AddNodeButton v-for="(node) in category.nodes" :key="node.name"
                        :node="node.name"
                        :name="node.name"
-                       :names="node.name === 'InModel' || node.name === 'OutModel'
-                        ? editorIONames : undefined"
         />
       </ButtonGrid>
     </ExpandablePanel>
@@ -21,6 +25,7 @@ import AddNodeButton from '@/components/buttons/AddNodeButton.vue';
 import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
 import { mapGetters } from 'vuex';
 import EditorManager from '@/EditorManager';
+import { ModelCategories } from '@/nodes/model/Types';
 
 @Component({
   components: {
@@ -32,5 +37,7 @@ import EditorManager from '@/EditorManager';
 })
 export default class LayersTab extends Vue {
   private modelNodes = EditorManager.getInstance().modelCanvas.nodeList;
+  private ioNodes = this.modelNodes[0];
+  private ioLabel = ModelCategories.IO;
 }
 </script>

--- a/src/store/editors/getters.ts
+++ b/src/store/editors/getters.ts
@@ -4,6 +4,7 @@ import { EditorModels, EditorsState } from '@/store/editors/types';
 import EditorType from '@/EditorType';
 import { ModelNodes } from '@/nodes/model/Types';
 import { SaveWithNames } from '@/file/EditorAsJson';
+import { DataNodes } from '@/nodes/data/Types';
 
 const editorGetters: GetterTree<EditorsState, RootState> = {
   currEditorType: (state) => state.currEditorType,
@@ -47,7 +48,9 @@ const editorGetters: GetterTree<EditorsState, RootState> = {
   editorIONames: (state, getters) => {
     const names: Set<string> = new Set<string>();
     for (const node of getters.currEditorModel.editor.nodes) {
-      if (node.type === ModelNodes.InModel || node.type === ModelNodes.OutModel) {
+      if (node.type === ModelNodes.InModel
+        || node.type === ModelNodes.OutModel
+        || node.type === DataNodes.InData) {
         names.add(node.name);
       }
     }


### PR DESCRIPTION
Implemented Node Colours for all (or most) nodes, including white theme for `Custom`.

Re-ordered all (applicable) node panels to have I/O first. Changed names of I/O buttons to `Input` and `Output`, rather than `InModel`, `OutModel`, and `InData`. 

Fixed bug where we didn't check uniqueness of `InData` nodes, so extended `editorIONames` to count `InData` nodes as well.