### PR TITLE
FE-88 Auto switch tabs when saving/cancelling on file in IDE

### DIFF
--- a/src/components/CodeVault.vue
+++ b/src/components/CodeVault.vue
@@ -1,6 +1,10 @@
 <template>
   <div class="vault">
-    <Tabs full-screen-tab="IDE">
+    <Tabs
+      full-screen-tab="IDE"
+      :selected-tab-index="tabIndex"
+      @changeTab="switchTab"
+    >
       <Tab name="Functions" :padded="false">
         <FunctionsTab/>
       </Tab>
@@ -9,7 +13,7 @@
         :key="file.filename"
         :name="file.filename"
         :padded="false">
-        <IdeTab :filename="file.filename"/>
+        <IdeTab :filename="file.filename" @switchToFunctions="close"/>
       </Tab>
     </Tabs>
   </div>
@@ -21,8 +25,7 @@ import Tabs from '@/components/tabs/Tabs.vue';
 import Tab from '@/components/tabs/Tab.vue';
 import FunctionsTab from '@/components/tabs/FunctionsTab.vue';
 import IdeTab from '@/components/tabs/IdeTab.vue';
-import { Getter } from 'vuex-class';
-import { ParsedFile } from '@/store/codeVault/types';
+import { mapGetters } from 'vuex';
 
 @Component({
   components: {
@@ -31,9 +34,18 @@ import { ParsedFile } from '@/store/codeVault/types';
     Tab,
     Tabs,
   },
+  computed: mapGetters(['openFiles']),
 })
 export default class CodeVault extends Vue {
-  @Getter('openFiles') openFiles!: ParsedFile[];
+  private tabIndex = 0;
+
+  private switchTab(newTab: number): void {
+    this.tabIndex = newTab;
+  }
+
+  private close(): void {
+    this.tabIndex -= 1;
+  }
 }
 </script>
 

--- a/src/components/CodeVault.vue
+++ b/src/components/CodeVault.vue
@@ -13,7 +13,7 @@
         :key="file.filename"
         :name="file.filename"
         :padded="false">
-        <IdeTab :filename="file.filename" @switchToFunctions="close"/>
+        <IdeTab :filename="file.filename" @closeTab="close"/>
       </Tab>
     </Tabs>
   </div>

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -64,7 +64,7 @@ export default class IdeTab extends Vue {
         this.setFile(file);
         this.closeFile(this.filename);
         this.$cookies.set(`unsaved-file-${this.filename}`, file);
-        this.$emit('switchToFunctions');
+        this.$emit('closeTab');
       } else {
         window.alert('Cannot save file with errors.');
       }
@@ -73,7 +73,7 @@ export default class IdeTab extends Vue {
 
   private cancel() {
     this.closeFile(this.filename);
-    this.$emit('switchToFunctions');
+    this.$emit('closeTab');
     this.linkNode(undefined); // Unlink node.
   }
 

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -64,6 +64,7 @@ export default class IdeTab extends Vue {
         this.setFile(file);
         this.closeFile(this.filename);
         this.$cookies.set(`unsaved-file-${this.filename}`, file);
+        this.$emit('switchToFunctions');
       } else {
         window.alert('Cannot save file with errors.');
       }
@@ -72,6 +73,7 @@ export default class IdeTab extends Vue {
 
   private cancel() {
     this.closeFile(this.filename);
+    this.$emit('switchToFunctions');
     this.linkNode(undefined); // Unlink node.
   }
 

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -14,19 +14,35 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import {
+  Component, Prop, Vue, Watch,
+} from 'vue-property-decorator';
 import Tab from '@/components/tabs/Tab.vue';
 
 @Component
 export default class Tabs extends Vue {
+  @Prop() selectedTabIndex?: number;
   private tabs = this.$children as [Tab];
   private selected = 0;
 
+  @Watch('selectedTabIndex')
+  private onTabSelectChange(newVal: number, oldVal: number) {
+    if (newVal !== oldVal) {
+      this.tabs[newVal].setVisible(true);
+      this.selected = newVal;
+      if (oldVal < this.tabs.length) this.tabs[oldVal].setVisible(false);
+    }
+  }
+
   private selectTab(given: number) {
-    this.selected = given;
-    this.tabs.forEach((tab, index) => {
-      tab.setVisible(index === given);
-    });
+    if (this.selectedTabIndex === undefined) {
+      this.selected = given;
+      this.tabs.forEach((tab, index) => {
+        tab.setVisible(index === given);
+      });
+    } else {
+      this.$emit('changeTab', given);
+    }
   }
 
   mounted() {


### PR DESCRIPTION
Refactored `Tabs` to take an optional super Prop which overrides internal selected field.

When `cancel` or `save` is called from the `IdeTab`, that tab is 'closed', and you are switched back to the `FunctionsTab`.

Switching to the tab when creating the file is non-trivial, so perhaps that can be a future TODO.