### PR TITLE
FE-74 Can delete files (which deletes nodes) and edit files

### DIFF
--- a/src/app/parser/ParsedFunction.ts
+++ b/src/app/parser/ParsedFunction.ts
@@ -3,6 +3,7 @@ class ParsedFunction {
     public readonly name: string,
     public readonly body: string,
     public readonly args: string[],
+    public readonly filename?: string,
   ) {
   }
 
@@ -12,6 +13,18 @@ class ParsedFunction {
 
   public toString(): string {
     return `${this.signature()}:\n${this.body}`;
+  }
+
+  public equals(other: ParsedFunction): boolean {
+    if (this.args.length !== other.args.length) return false;
+
+    const sortedArgs = this.args.slice().sort();
+    const otherSortedArgs = other.args.slice().sort();
+    for (let i = 0; i < this.args.length; i += 1) {
+      if (sortedArgs[i] !== otherSortedArgs[i]) return false;
+    }
+
+    return this.name === other.name && this.body === other.body && this.filename === other.filename;
   }
 }
 

--- a/src/app/parser/parser.ts
+++ b/src/app/parser/parser.ts
@@ -53,7 +53,7 @@ function parseFunctionSignature(line: string): FunctionSignature | null {
   );
 }
 
-function parse(str: string): Result<ParsedFunction[]> {
+function parse(str: string, filename?: string): Result<ParsedFunction[]> {
   const indentation = getIndentation(str);
 
   // If we failed to get the indentation level
@@ -88,6 +88,7 @@ function parse(str: string): Result<ParsedFunction[]> {
           currentSignature!.name,
           currentBody!,
           currentSignature!.args,
+          filename,
         ));
 
         isParsingFunction = false;

--- a/src/components/buttons/FileFuncButton.vue
+++ b/src/components/buttons/FileFuncButton.vue
@@ -1,6 +1,14 @@
 <template>
-  <div class="func-button" :class="selected && 'selected'" @click="$emit('click')">
-    <div class="header">{{ header }}</div>
+  <div
+    class="func-button"
+    :class="selected && 'selected'"
+    @click="$emit('click')"
+  >
+    <div
+      class="header"
+      v-if="header !== undefined"
+      v-text="header"
+    />
     <div class="body">
       <slot/>
     </div>
@@ -12,7 +20,7 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 
 @Component
 export default class FileFuncButton extends Vue {
-  @Prop({ required: true }) readonly header!: string;
+  @Prop({ required: false }) readonly header?: string;
   @Prop({ default: false }) readonly selected?: boolean;
 }
 </script>

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -54,7 +54,7 @@
     <div
       class="build tab-button"
       :class="inCodeVault && 'selected'"
-      @click="clickCodeVault"
+      @click="enterCodeVault"
     >
       <i class="fab fa-python tab-icon"/>
     </div>
@@ -64,7 +64,7 @@
 <script lang="ts">
 import { Vue, Component } from 'vue-property-decorator';
 import EditorType from '@/EditorType';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapMutations } from 'vuex';
 import { Getter, Mutation } from 'vuex-class';
 import NavbarContextualMenu from '@/components/navbar/NavbarContextualMenu.vue';
 import { EditorSave, saveEditor } from '@/file/EditorAsJson';
@@ -77,6 +77,7 @@ import { EditorModel } from '@/store/editors/types';
     'dataEditors',
     'inCodeVault',
   ]),
+  methods: mapMutations(['enterCodeVault']),
 })
 export default class Navbar extends Vue {
   private editorType = EditorType;
@@ -88,8 +89,6 @@ export default class Navbar extends Vue {
   @Getter('inCodeVault') inCodeVault!: boolean;
   @Mutation('switchEditor') switch!: (arg0: { editorType: EditorType; index: number }) => void;
   @Mutation('updateNodeInOverview') readonly updateNodeInOverview!: (cEditor: EditorModel) => void;
-  @Mutation('enterCodeVault') enterCodeVault!: () => void;
-  @Mutation('closeFiles') closeFiles!: () => void;
 
   private switchOverviewEditor() {
     // Save currEditorModel before switching as periodic save may not have captured last changes
@@ -124,11 +123,6 @@ export default class Navbar extends Vue {
   private hideNavbarContextualMenu(): void {
     this.isModelContextualMenuOpen = false;
     this.isDataContextualMenuOpen = false;
-  }
-
-  private clickCodeVault() {
-    this.closeFiles();
-    this.enterCodeVault();
   }
 }
 

--- a/src/components/tabs/CustomTab.vue
+++ b/src/components/tabs/CustomTab.vue
@@ -3,7 +3,7 @@
     <div
       class="msg"
       v-if="files.length === 0"
-      @click="clickCodeVault"
+      @click="enterCodeVault"
     >
       Click Here to Add Custom Functions
     </div>
@@ -27,7 +27,7 @@
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
-import { mapGetters } from 'vuex';
+import { mapGetters, mapMutations } from 'vuex';
 import ExpandablePanel from '@/components/ExpandablePanel.vue';
 import AddNodeButton from '@/components/buttons/AddNodeButton.vue';
 import ButtonGrid from '@/components/buttons/ButtonGrid.vue';
@@ -41,17 +41,10 @@ import { Mutation } from 'vuex-class';
     ButtonGrid,
   },
   computed: mapGetters(['files']),
+  methods: mapMutations(['enterCodeVault']),
 })
 export default class CustomTab extends Vue {
   private customNode: string = CommonNodes.Custom;
-
-  @Mutation('enterCodeVault') enterCodeVault!: () => void;
-  @Mutation('closeFiles') closeFiles!: () => void;
-
-  private clickCodeVault() {
-    this.closeFiles();
-    this.enterCodeVault();
-  }
 }
 </script>
 

--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="d-flex h-100">
+
     <div id="left" class="panel">
       <div class="d-flex">
         <div>
@@ -24,45 +25,43 @@
           @click="selectFile(index)"
         >
           <div v-if="getFunctions(index).length === 0">(empty)</div>
-          <div v-else>
-            <div v-for="(func, index) of getFunctions(index)" :key="index">
-              {{ func.signature() }}
-            </div>
+          <div v-else v-for="(func, index) of getFunctions(index)" :key="index">
+            {{ func.signature() }}
           </div>
         </FileFuncButton>
       </div>
     </div>
+
     <div id="right" class="panel">
       <div class="button-list">
-        <div v-if="getFunctions(selectedFile).length === 0" class="text-center">
-          {{ selectedFile === -1 ? 'Select a file.' : 'No functions defined!' }}
-        </div>
-        <FileFuncButton
-          v-for="(func, index) of getFunctions(selectedFile)"
-          :header="`def ${func.name}`"
-          :key="index"
-          :selected="selectedFunction === index"
-          @click="selectFunction(index)"
-        >
-          {{
-            func.toString()
-              .slice(0, 100) + (func.toString().length > 100 ? '...' : '')
-          }}
+        <FileFuncButton :disableHover="true">
+          <div v-if="this.selectedFile === -1" class="text-center">
+            No File Selected
+          </div>
+          <div
+            v-else
+            class="pre-formatted"
+            v-for="(func) of getFunctions(selectedFile)"
+            :key="func.name"
+            v-text="`${func.toString()}\n`"
+          />
         </FileFuncButton>
       </div>
       <div class="confirm-button">
         <UIButton
-          text="Cancel"
-          @click="cancelClick"
+          text="Delete"
+          @click="deleteFile"
+          :disabled="this.selectedFile === -1"
         />
         <UIButton
-          text="Confirm"
+          text="Edit"
           :primary="true"
-          @click="confirmClick"
-          :disabled="selectedFunction === -1"
+          @click="editFile"
+          :disabled="this.selectedFile === -1"
         />
       </div>
     </div>
+
   </div>
 </template>
 
@@ -88,7 +87,6 @@ import FileFuncButton from '@/components/buttons/FileFuncButton.vue';
   },
 })
 export default class FunctionsTab extends Vue {
-  @Mutation('leaveCodeVault') leaveCodeVault!: () => void;
   @Getter('filenames') filenames!: Set<string>;
   @Getter('file') file!: (filename: string) => ParsedFile | undefined;
   @Getter('files') files!: ParsedFile[];
@@ -96,19 +94,9 @@ export default class FunctionsTab extends Vue {
   @Getter('filenamesList') filenamesList!: FilenamesList;
 
   private selectedFile = -1;
-  private selectedFunction = -1;
 
   private selectFile(index: number) {
     this.selectedFile = index;
-    this.selectedFunction = -1;
-  }
-
-  private selectFunction(index: number) {
-    if (index === this.selectedFunction) {
-      this.selectedFunction = -1;
-    } else {
-      this.selectedFunction = index;
-    }
   }
 
   private getFunctions(index: number): ParsedFunction[] {
@@ -165,12 +153,12 @@ export default class FunctionsTab extends Vue {
     this.saveToCookies(file);
   }
 
-  private confirmClick() {
-    console.log(`Clicked with selected file ${this.selectedFile} and function ${this.selectedFunction}`);
+  private deleteFile() {
+    console.log(`Clicked delete with selected file ${this.selectedFile}`);
   }
 
-  private cancelClick() {
-    this.leaveCodeVault();
+  private editFile() {
+    console.log(`Clicked edit selected file ${this.selectedFile}`);
   }
 
   private saveToCookies(file: ParsedFile) {
@@ -211,5 +199,9 @@ export default class FunctionsTab extends Vue {
 
   .button {
     margin-right: 1em;
+  }
+
+  .pre-formatted {
+    white-space: pre;
   }
 </style>

--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -94,10 +94,11 @@ import { mapGetters } from 'vuex';
 export default class FunctionsTab extends Vue {
   @Getter('filenames') filenames!: Set<string>;
   @Getter('file') file!: (filename: string) => ParsedFile;
+  @Getter('filenamesList') filenamesList!: FilenamesList;
   @Mutation('addFile') addFile!: (file: ParsedFile) => void;
   @Mutation('deleteFile') delFile!: (filename: string) => void;
   @Mutation('openFile') openFile!: (filename: string) => void;
-  @Getter('filenamesList') filenamesList!: FilenamesList;
+  @Mutation('deleteNodes') deleteNodes!: (functions: ParsedFunction[]) => void;
 
   private selectedFile: string | null = null;
 
@@ -132,7 +133,7 @@ export default class FunctionsTab extends Vue {
       }
 
       // Parse file - report any errors
-      const parsed: Result<ParsedFunction[]> = parse(event.target.result as string);
+      const parsed: Result<ParsedFunction[]> = parse(event.target.result as string, filename);
       if (parsed instanceof Error) {
         console.error(parsed);
       } else {
@@ -158,9 +159,15 @@ export default class FunctionsTab extends Vue {
   }
 
   private deleteFile() {
-    // TODO: Ran through nodes using function and remove nodes
     if (this.selectedFile !== null) {
       const filename = this.selectedFile;
+
+      // Run through editors using function in deleted file and remove corresponding nodes
+      // TODO: Add warning confirming nodes will be deleted?
+      const { functions } = this.file(filename);
+      this.deleteNodes(functions);
+
+      // Delete file from codevault
       this.selectedFile = null;
       this.delFile(filename);
     }

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -1,13 +1,9 @@
 <template>
-  <div class="h-100">
+  <div class="editor">
     <div id="ace"/>
-    <div class="save-banner">
-      <div>
-        <UIButton text="Cancel" @click="cancel"/>
-      </div>
-      <div>
-        <UIButton text="Save Changes" :primary="true" @click="save"/>
-      </div>
+    <div class="confirm-button">
+      <UIButton text="Close" @click="close"/>
+      <UIButton text="Save Changes" :primary="true" @click="save"/>
     </div>
   </div>
 </template>
@@ -19,7 +15,7 @@ import Tab from '@/components/tabs/Tab.vue';
 import Ace from 'brace';
 import 'brace/mode/python';
 import '@/assets/ivann-theme';
-import { Mutation } from 'vuex-class';
+import { Getter, Mutation } from 'vuex-class';
 import Custom from '@/nodes/common/Custom';
 import UIButton from '@/components/buttons/UIButton.vue';
 import parse from '@/app/parser/parser';
@@ -37,6 +33,7 @@ import { ParsedFile } from '@/store/codeVault/types';
 export default class IdeTab extends Vue {
   @Prop({ required: true }) readonly filename!: string;
 
+  @Getter('file') file!: (filename: string) => ParsedFile;
   @Mutation('setFile') setFile!: (file: ParsedFile) => void;
   @Mutation('closeFile') closeFile!: (filename: string) => void;
   @Mutation('leaveCodeVault') leaveCodeVault!: () => void;
@@ -54,9 +51,13 @@ export default class IdeTab extends Vue {
     });
     this.editor.$blockScrolling = Infinity; // Get rid unnecessary Console info
     this.editor.on('change', this.onEditorChange);
+
+    // Initialise file with current functions that it contains
+    this.editor.setValue(this.file(this.filename).functions.join('\n'));
   }
 
   private save() {
+    // TODO: Compare new file with prev file and update / delete nodes accordingly
     if (this.editor) {
       if (!(this.parsedFile instanceof Error) && this.parsedFile) {
         const file = { filename: this.filename, functions: this.parsedFile, open: false };
@@ -70,7 +71,7 @@ export default class IdeTab extends Vue {
     }
   }
 
-  private cancel() {
+  private close() {
     this.closeFile(this.filename);
     this.$emit('closeTab');
   }
@@ -105,22 +106,27 @@ export default class IdeTab extends Vue {
 </script>
 
 <style scoped>
-.save-banner {
-  border-top: 1px solid var(--grey);
-  background: var(--background);
-  height: 3em;
-  display: flex;
-  padding-left: calc(100% - 15.5em);
-}
 .button {
-  margin-top: 14px;
   margin-right: 1rem;
 }
+
+.editor {
+  margin-bottom: 1em;
+  height: calc(100% - 2.5em);
+}
+
 #ace {
   border-top: 1px solid var(--grey);
-  height: calc(100% - 3em);
+  height: calc(100%);
   font-size: 1em;
   font-family: monospace;
   font-weight: lighter;
+}
+
+.confirm-button {
+  display: flex;
+  float: right;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
 }
 </style>

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -16,7 +16,6 @@ import Ace from 'brace';
 import 'brace/mode/python';
 import '@/assets/ivann-theme';
 import { Getter, Mutation } from 'vuex-class';
-import Custom from '@/nodes/common/Custom';
 import UIButton from '@/components/buttons/UIButton.vue';
 import parse from '@/app/parser/parser';
 import ParsedFunction from '@/app/parser/ParsedFunction';
@@ -57,13 +56,23 @@ export default class IdeTab extends Vue {
   }
 
   private save() {
-    // TODO: Compare new file with prev file and update / delete nodes accordingly
     if (this.editor) {
       if (!(this.parsedFile instanceof Error) && this.parsedFile) {
-        const file = { filename: this.filename, functions: this.parsedFile, open: false };
+        const funcs = this.parsedFile as ParsedFunction[];
+
+        // Compare old file and new file, checking differences
+        // TODO
+
+        // Run through editors using function that have been changed and update corresponding nodes
+        // TODO
+
+        // Override file in codevault and save
+        const file = { filename: this.filename, functions: funcs, open: false };
         this.setFile(file);
-        this.closeFile(this.filename);
         this.$cookies.set(`unsaved-file-${this.filename}`, file);
+
+        // Close tab and switch to 'Functions' tab
+        this.closeFile(this.filename);
         this.$emit('closeTab');
       } else {
         window.alert('Cannot save file with errors.');
@@ -82,7 +91,7 @@ export default class IdeTab extends Vue {
   private onEditorChange() {
     if (this.editor) {
       const code = this.editor.getValue();
-      const functionsOrError = parse(code);
+      const functionsOrError = parse(code, this.filename);
       if (!(functionsOrError instanceof Error)) {
         this.editor.getSession().clearAnnotations();
       } else {

--- a/src/nodes/common/Custom.ts
+++ b/src/nodes/common/Custom.ts
@@ -35,7 +35,12 @@ export default class Custom extends Node {
     const { parsedFunction } = savedState ? savedState.state : this.state;
     if (parsedFunction) {
       // Conversion is necessary because Baklava State saves as generic `any`.
-      return new ParsedFunction(parsedFunction.name, parsedFunction.body, parsedFunction.args);
+      return new ParsedFunction(
+        parsedFunction.name,
+        parsedFunction.body,
+        parsedFunction.args,
+        parsedFunction.filename,
+      );
     }
     return undefined;
   }

--- a/src/store/codeVault/mutations.ts
+++ b/src/store/codeVault/mutations.ts
@@ -13,7 +13,7 @@ const codeVaultMutations: MutationTree<CodeVaultState> = {
         filename: file.filename,
         functions: file.functions.map(
           /* JSON parses functions to an interface, not to the ParsedFunction object. */
-          (func) => new ParsedFunction(func.name, func.body, func.args),
+          (func) => new ParsedFunction(func.name, func.body, func.args, func.filename),
         ),
         open: false,
       });

--- a/src/store/codeVault/mutations.ts
+++ b/src/store/codeVault/mutations.ts
@@ -1,7 +1,6 @@
 import { MutationTree } from 'vuex';
 import { CodeVaultState, ParsedFile } from '@/store/codeVault/types';
 import ParsedFunction from '@/app/parser/ParsedFunction';
-import Custom from '@/nodes/common/Custom';
 
 const codeVaultMutations: MutationTree<CodeVaultState> = {
   resetState(state) {

--- a/src/store/codeVault/mutations.ts
+++ b/src/store/codeVault/mutations.ts
@@ -47,6 +47,11 @@ const codeVaultMutations: MutationTree<CodeVaultState> = {
       return file;
     });
   },
+  openFile(state, filename: string) {
+    for (const file of state.files) {
+      if (file.filename === filename) file.open = true;
+    }
+  },
   closeFiles(state) {
     state.files = state.files.map((file) => ({ ...file, open: false }));
   },

--- a/src/store/editors/index.ts
+++ b/src/store/editors/index.ts
@@ -3,7 +3,6 @@ import { randomUuid } from '@/app/util';
 import { RootState } from '@/store/types';
 import EditorType from '@/EditorType';
 import newEditor from '@/baklava/Utils';
-import IrError from '@/app/ir/checking/irError';
 import editorGetters from './getters';
 import editorMutations from './mutations';
 import { EditorsState } from './types';

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -8,7 +8,7 @@ import { loadEditors, Save } from '@/file/EditorAsJson';
 import { randomUuid, UUID } from '@/app/util';
 import Model from '@/nodes/overview/Model';
 import editorIOPartition, { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
-import { getEditorIOs } from '@/store/editors/utils';
+import { deleteNodesFromEditor, getEditorIOs } from '@/store/editors/utils';
 
 const editorMutations: MutationTree<EditorsState> = {
   switchEditor(state, { editorType, index }) {
@@ -178,6 +178,11 @@ const editorMutations: MutationTree<EditorsState> = {
   },
   setErrorsMap(state, errorsMap) {
     state.errorsMap = errorsMap;
+  },
+  deleteNodes(state, functions) {
+    deleteNodesFromEditor(state.overviewEditor, functions);
+    state.modelEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
+    state.dataEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
   },
 };
 

--- a/src/store/editors/utils.ts
+++ b/src/store/editors/utils.ts
@@ -1,5 +1,7 @@
 import { EditorModel } from '@/store/editors/types';
 import { ModelNodes } from '@/nodes/model/Types';
+import ParsedFunction from '@/app/parser/ParsedFunction';
+import Custom from '@/nodes/common/Custom';
 
 export function getEditorIOs(editorModel: EditorModel): { inputs: string[]; outputs: string[] } {
   const inputs: string[] = [];
@@ -18,4 +20,51 @@ export function getEditorIOs(editorModel: EditorModel): { inputs: string[]; outp
   }
 
   return { inputs, outputs };
+}
+
+export interface FuncDiff {
+  deleted: ParsedFunction[];
+  changed: ({
+    oldFunc: ParsedFunction;
+    newFunc: ParsedFunction;
+    args: { deleted: string[]; added: string[] };
+  })[];
+}
+
+/*
+Compares two ParsedFunction arrays
+Returns object containing:
+  deleted:
+    - If function is in oldFunc but not in newFunc
+  changed:
+    - If function in oldFunc is present in newFunc but has been changed
+    - Changed if same name but different args and/or body
+    - Contains:
+        oldFunc - function that was changed
+        newFunc - function it has become
+        args:
+          deleted - args that was in oldFunc but not in newFunc
+          added - args that was not in oldFunc but is in newFunc
+ */
+export function funcsDiff(
+  oldFuncs: ParsedFunction[], newFuncs: ParsedFunction[],
+): FuncDiff {
+  return {
+    deleted: [],
+    changed: [],
+  };
+}
+
+export function deleteNodesFromEditor(editorModel: EditorModel, funcs: ParsedFunction[]) {
+  const { editor } = editorModel;
+  const { nodes } = editor;
+
+  // Have to loop through copy of nodes, otherwise by removing node, we modify array of nodes st
+  // we don't remove duplicate custom nodes
+  for (const node of nodes.slice()) {
+    if (node instanceof Custom) {
+      const func = (node as Custom).getParsedFunction() as ParsedFunction;
+      if (funcs.some((f) => f.equals(func))) editor.removeNode(node);
+    }
+  }
 }


### PR DESCRIPTION
Can edit / delete files from codevault.

Codevault gives preview of file contents (needs to be styled)

If click on `delete` after selecting file, will delete file and all instances of custom nodes that use functions in the deleted file (NOTE no warning currently, should this be added?)

If click on `edit` opens tab (does not switch tabs for you currently). Tab is preloaded with current contents and can update file contents by clicking on `save`. (NOTE bottom border above buttons has not been added - @tomproberts can you do this? Needs to be added to class `ace-scroller` but not sure how to access this.)

Set up function for updating corresponding nodes after editting file (FE-101) 