### PR TITLE
FE-36 Styled nodes a little better

### DIFF
--- a/src/assets/scss/_general.scss
+++ b/src/assets/scss/_general.scss
@@ -1,4 +1,5 @@
 html, body {
   overflow-x: hidden;
   font-size: 20px;
+  font-family: Roboto, sans-serif;
 }

--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -20,6 +20,7 @@
            id="arrow-button"
            :initialUp="true"
            v-on:arrow-button-clicked="toggleShouldShowOptions"
+           v-show="data.options.size > 0"
          />
       </span>
       <input
@@ -243,7 +244,7 @@ export default class CustomNode extends Components.Node {
   }
 
   .node {
-    /*font-family: Roboto, serif;*/
+    font-family: Roboto, serif;
     font-size: 14px;
     &:hover {
       box-shadow: 0 0 0 0.35px var(--blue);

--- a/src/baklava/input/CheckboxInput.vue
+++ b/src/baklava/input/CheckboxInput.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="checkbox" :class="checked !== uncheckedValue && 'checked'" @click="clicked">
-    <span v-if="checked === checkedValue" class="tick">✓</span>
-    <span v-else-if="checked === halfCheckedValue" class="dash">-</span>
+  <div class="checkbox" :class="checked !== checkboxValue.UNCHECKED && 'checked'" @click="clicked">
+    <span v-if="checked === checkboxValue.CHECKED" class="tick">✓</span>
+    <span v-else-if="checked === checkboxValue.HALFCHECKED" class="dash">-</span>
   </div>
 </template>
 
@@ -13,9 +13,13 @@ import CheckboxValue from '@/baklava/CheckboxValue';
 export default class CheckboxInput extends Vue {
   @Prop({ required: true }) checked!: CheckboxValue;
 
-  private checkedValue = CheckboxValue.CHECKED;
-  private halfCheckedValue = CheckboxValue.HALFCHECKED;
-  private uncheckedValue = CheckboxValue.UNCHECKED;
+  private checkboxValue = CheckboxValue;
+
+  created() {
+    if (this.checked === null) {
+      this.$emit('value-change', CheckboxValue.CHECKED);
+    }
+  }
 
   private clicked() {
     const newValue: CheckboxValue = this.checked === CheckboxValue.UNCHECKED
@@ -59,12 +63,12 @@ export default class CheckboxInput extends Vue {
   }
 
   .tick {
-    left: 0.15rem;
-    top: -0.15rem;
+    left: 0.13rem;
+    top: -0.1rem;
   }
 
   .dash {
     left: 0.3rem;
-    top: -0.25rem;
+    top: -0.15rem;
   }
 </style>

--- a/src/baklava/input/DropdownInput.vue
+++ b/src/baklava/input/DropdownInput.vue
@@ -50,6 +50,7 @@ export default class DropdownInput extends Vue {
     background: #ececec;
     border-radius: 2px;
     color: #303030;
+    height: 1rem;
   }
 
   .button:hover {
@@ -57,7 +58,7 @@ export default class DropdownInput extends Vue {
   }
 
   .icon {
-    padding: 0 0.3em 0.2em 0.1em;
+    padding: 0 0.3em 0.2em 0.4em;
   }
 
   .dropdown-container {

--- a/src/baklava/input/IntegerInc.vue
+++ b/src/baklava/input/IntegerInc.vue
@@ -84,6 +84,7 @@ export default class IntegerInc extends Vue {
     border-radius: 2px;
     color: #303030;
     display: flex;
+    height: 1rem;
   }
 
   .buttons {

--- a/src/components/buttons/AddNodeButton.vue
+++ b/src/components/buttons/AddNodeButton.vue
@@ -34,7 +34,7 @@ export default class AddNodeButton extends Vue {
     let factor = (this.name.length - 10) / 3;
     if (factor > 0) {
       if (factor > 3) factor = 3;
-      this.fontSize -= 0.15 * factor;
+      this.fontSize -= 0.18 * factor;
     }
   }
 

--- a/src/inputs/ArrowButton.vue
+++ b/src/inputs/ArrowButton.vue
@@ -1,7 +1,17 @@
 <template>
   <div v-on:click="onClick">
-    <div v-if="up">▲</div>
-    <div v-else>▼</div>
+    <div v-if="up">
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
+        <line x1="1" y1="8" x2="7" y2="1" fill="none" stroke="#ececec" stroke-width="2"/>
+        <line x1="11.8" y1="8" x2="5.8" y2="1" fill="none" stroke="#ececec" stroke-width="2"/>
+      </svg>
+    </div>
+    <div v-else>
+      <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
+        <line x1="1" y1="1" x2="7" y2="8" fill="none" stroke="#ececec" stroke-width="2"/>
+        <line x1="11.8" y1="1" x2="5.8" y2="8" fill="none" stroke="#ececec" stroke-width="2"/>
+      </svg>
+    </div>
   </div>
 </template>
 
@@ -20,6 +30,3 @@ export default class ArrowButton extends Vue {
   }
 }
 </script>
-
-<style>
-</style>


### PR DESCRIPTION
But now everything has Roboto font, which **IS** what was initially intended.

Now only render node dropdown thing there are actually options to show, (e.g. `InModel` nodes have no configurable options), and also made it look like our other arrow looking things.

Fixed the issue where some nodes had their `Checkbox`s incorrectly initialised, though I still blame _Kacper_ for that.

And a few other general CSS changes to do with the fact that the font changed.