### PR TITLE
FE-101 Update nodes on edit

### DIFF
--- a/src/components/canvas/ModelCanvas.ts
+++ b/src/components/canvas/ModelCanvas.ts
@@ -23,8 +23,6 @@ import Softmax from '@/nodes/model/Softmax';
 import Bilinear from '@/nodes/model/Bilinear';
 import Linear from '@/nodes/model/Linear';
 import { Editor } from '@baklavajs/core';
-import { CommonNodes } from '@/nodes/common/Types';
-import Custom from '@/nodes/common/Custom';
 
 export default class ModelCanvas extends AbstractCanvas {
   public nodeList = [

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -21,6 +21,7 @@ import parse from '@/app/parser/parser';
 import ParsedFunction from '@/app/parser/ParsedFunction';
 import { Result } from '@/app/util';
 import { ParsedFile } from '@/store/codeVault/types';
+import { FuncDiff, funcsDiff } from '@/store/editors/utils';
 
 @Component({
   components: {
@@ -36,6 +37,8 @@ export default class IdeTab extends Vue {
   @Mutation('setFile') setFile!: (file: ParsedFile) => void;
   @Mutation('closeFile') closeFile!: (filename: string) => void;
   @Mutation('leaveCodeVault') leaveCodeVault!: () => void;
+  @Mutation('editNodes') editNodes!: (diff: FuncDiff) => void;
+
   private editor?: Ace.Editor;
   private parsedFile?: Result<ParsedFunction[]>;
 
@@ -58,16 +61,18 @@ export default class IdeTab extends Vue {
   private save() {
     if (this.editor) {
       if (!(this.parsedFile instanceof Error) && this.parsedFile) {
-        const funcs = this.parsedFile as ParsedFunction[];
+        const oldFuncs = this.file(this.filename).functions;
+        const newFuncs = this.parsedFile as ParsedFunction[];
 
-        // Compare old file and new file, checking differences
-        // TODO
+        // Compare old file and new file, finding differences
+        const diff: FuncDiff = funcsDiff(oldFuncs, newFuncs);
+        // TODO: FE-103 Warning depending on diff
 
         // Run through editors using function that have been changed and update corresponding nodes
-        // TODO
+        this.editNodes(diff);
 
         // Override file in codevault and save
-        const file = { filename: this.filename, functions: funcs, open: false };
+        const file = { filename: this.filename, functions: newFuncs, open: false };
         this.setFile(file);
         this.$cookies.set(`unsaved-file-${this.filename}`, file);
 

--- a/src/nodes/common/Custom.ts
+++ b/src/nodes/common/Custom.ts
@@ -28,7 +28,14 @@ export default class Custom extends Node {
 
   public setParsedFunction(parsedFunction?: ParsedFunction) {
     this.state.parsedFunction = parsedFunction;
-    this.updateNode();
+  }
+
+  public addInput(name: string): void {
+    this.addInputInterface(name);
+  }
+
+  public remInteface(name: string): void {
+    this.removeInterface(name);
   }
 
   public getParsedFunction(savedState?: INodeState): (ParsedFunction | undefined) {
@@ -43,14 +50,6 @@ export default class Custom extends Node {
       );
     }
     return undefined;
-  }
-
-  public setParsedFileName(parsedFileName?: string) {
-    this.state.parsedFileName = parsedFileName;
-  }
-
-  public getParsedFileName(): (string | undefined) {
-    return this.state.parsedFileName;
   }
 
   private updateNode(savedState?: INodeState) {

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -8,7 +8,12 @@ import { loadEditors, Save } from '@/file/EditorAsJson';
 import { randomUuid, UUID } from '@/app/util';
 import Model from '@/nodes/overview/Model';
 import editorIOPartition, { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
-import { deleteNodesFromEditor, getEditorIOs } from '@/store/editors/utils';
+import {
+  deleteNodesFromEditor,
+  editNodesFromEditor,
+  FuncDiff,
+  getEditorIOs,
+} from '@/store/editors/utils';
 
 const editorMutations: MutationTree<EditorsState> = {
   switchEditor(state, { editorType, index }) {
@@ -183,6 +188,11 @@ const editorMutations: MutationTree<EditorsState> = {
     deleteNodesFromEditor(state.overviewEditor, functions);
     state.modelEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
     state.dataEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
+  },
+  editNodes(state, diff: FuncDiff) {
+    editNodesFromEditor(state.overviewEditor, diff);
+    state.modelEditors.forEach((editor) => editNodesFromEditor(editor, diff));
+    state.dataEditors.forEach((editor) => editNodesFromEditor(editor, diff));
   },
 };
 

--- a/src/store/editors/mutations.ts
+++ b/src/store/editors/mutations.ts
@@ -8,12 +8,8 @@ import { loadEditors, Save } from '@/file/EditorAsJson';
 import { randomUuid, UUID } from '@/app/util';
 import Model from '@/nodes/overview/Model';
 import editorIOPartition, { NodeIOChange } from '@/nodes/overview/EditorIOUtils';
-import {
-  deleteNodesFromEditor,
-  editNodesFromEditor,
-  FuncDiff,
-  getEditorIOs,
-} from '@/store/editors/utils';
+import { editNodes, FuncDiff, getEditorIOs } from '@/store/editors/utils';
+import ParsedFunction from '@/app/parser/ParsedFunction';
 
 const editorMutations: MutationTree<EditorsState> = {
   switchEditor(state, { editorType, index }) {
@@ -184,15 +180,15 @@ const editorMutations: MutationTree<EditorsState> = {
   setErrorsMap(state, errorsMap) {
     state.errorsMap = errorsMap;
   },
-  deleteNodes(state, functions) {
-    deleteNodesFromEditor(state.overviewEditor, functions);
-    state.modelEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
-    state.dataEditors.forEach((editor) => deleteNodesFromEditor(editor, functions));
+  deleteNodes(state, funcs: ParsedFunction[]) {
+    editNodes(state.overviewEditor, { deleted: funcs, changed: [] });
+    state.modelEditors.forEach((editor) => editNodes(editor, { deleted: funcs, changed: [] }));
+    state.dataEditors.forEach((editor) => editNodes(editor, { deleted: funcs, changed: [] }));
   },
   editNodes(state, diff: FuncDiff) {
-    editNodesFromEditor(state.overviewEditor, diff);
-    state.modelEditors.forEach((editor) => editNodesFromEditor(editor, diff));
-    state.dataEditors.forEach((editor) => editNodesFromEditor(editor, diff));
+    editNodes(state.overviewEditor, diff);
+    state.modelEditors.forEach((editor) => editNodes(editor, diff));
+    state.dataEditors.forEach((editor) => editNodes(editor, diff));
   },
 };
 

--- a/src/store/editors/utils.ts
+++ b/src/store/editors/utils.ts
@@ -49,10 +49,38 @@ Returns object containing:
 export function funcsDiff(
   oldFuncs: ParsedFunction[], newFuncs: ParsedFunction[],
 ): FuncDiff {
-  return {
-    deleted: [],
-    changed: [],
-  };
+  const deleted: ParsedFunction[] = [];
+  const changed: ({
+    oldFunc: ParsedFunction;
+    newFunc: ParsedFunction;
+    args: { deleted: string[]; added: string[] };
+  })[] = [];
+
+  oldFuncs.forEach((oldFunc) => {
+    const isPresent = newFuncs.some((newFunc) => newFunc.name === oldFunc.name);
+
+    // If not present, then has been deleted
+    // Else is present and must check if has changed
+    if (!isPresent) {
+      deleted.push(oldFunc);
+      console.log(`deleted ${oldFunc.name}`);
+    } else {
+      const newFunc = newFuncs.find((newFunc) => newFunc.name === oldFunc.name);
+
+      // Do not add to changed array if same function
+      if (newFunc === undefined || oldFunc.equals(newFunc)) return;
+
+      const deletedArgs: string[] = oldFunc.args.filter((arg) => !newFunc.args.includes(arg));
+      const addedArgs: string[] = newFunc.args.filter((arg) => !oldFunc.args.includes(arg));
+      changed.push({
+        oldFunc,
+        newFunc,
+        args: { deleted: deletedArgs, added: addedArgs },
+      });
+    }
+  });
+
+  return { deleted, changed };
 }
 
 export function deleteNodesFromEditor(editorModel: EditorModel, funcs: ParsedFunction[]) {
@@ -65,6 +93,31 @@ export function deleteNodesFromEditor(editorModel: EditorModel, funcs: ParsedFun
     if (node instanceof Custom) {
       const func = (node as Custom).getParsedFunction() as ParsedFunction;
       if (funcs.some((f) => f.equals(func))) editor.removeNode(node);
+    }
+  }
+}
+
+export function editNodesFromEditor(editorModel: EditorModel, diff: FuncDiff) {
+  const { editor } = editorModel;
+  const { nodes } = editor;
+
+  // Have to loop through copy of nodes, otherwise by removing node, we modify array of nodes st
+  // we don't remove duplicate custom nodes
+  for (const node of nodes.slice()) {
+    if (node instanceof Custom) {
+      const func = (node as Custom).getParsedFunction() as ParsedFunction;
+
+      // Remove node if deleted
+      if (diff.deleted.some((f) => f.equals(func))) editor.removeNode(node);
+
+      // Update node if changed
+      const change = diff.changed.find((elem) => elem.oldFunc.name === func.name
+        && elem.oldFunc.filename === func.filename);
+      if (change) {
+        node.setParsedFunction(change.newFunc);
+        change.args.added.forEach((arg) => node.addInput(arg));
+        change.args.deleted.forEach((arg) => node.remInteface(arg));
+      }
     }
   }
 }

--- a/src/store/editors/utils.ts
+++ b/src/store/editors/utils.ts
@@ -83,21 +83,7 @@ export function funcsDiff(
   return { deleted, changed };
 }
 
-export function deleteNodesFromEditor(editorModel: EditorModel, funcs: ParsedFunction[]) {
-  const { editor } = editorModel;
-  const { nodes } = editor;
-
-  // Have to loop through copy of nodes, otherwise by removing node, we modify array of nodes st
-  // we don't remove duplicate custom nodes
-  for (const node of nodes.slice()) {
-    if (node instanceof Custom) {
-      const func = (node as Custom).getParsedFunction() as ParsedFunction;
-      if (funcs.some((f) => f.equals(func))) editor.removeNode(node);
-    }
-  }
-}
-
-export function editNodesFromEditor(editorModel: EditorModel, diff: FuncDiff) {
+export function editNodes(editorModel: EditorModel, diff: FuncDiff) {
   const { editor } = editorModel;
   const { nodes } = editor;
 


### PR DESCRIPTION
On an edit of a file, we will ran through all the nodes in all the editors. We will then update any instances of custom nodes that have been effected by the edit.
* If changed body, update body (does not effect interfaces)
* If changed args:
     * if added then add interface
     * if deleted, remove connection and delete interface
* Renaming treated like a deletion

No warnings currently (FE-103) but know exactly what has changed after parsing so will be easy add