### PR TITLE
Move cookies to Local Storage, and add on Load (FE-65)

### DIFF
--- a/src/components/buttons/DeleteEditorButton.vue
+++ b/src/components/buttons/DeleteEditorButton.vue
@@ -25,11 +25,11 @@ export default class DeleteEditorButton extends Vue {
 
     // Re-save overview after nodes may have been removed
     const overviewEditorSave = saveEditor(this.overviewEditor);
-    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+    localStorage.setItem('unsaved-editor-Overview', JSON.stringify(overviewEditorSave));
 
-    // Remove deleted editor from saved cookies
-    this.$cookies.remove(`unsaved-editor-${this.name}`);
-    this.$cookies.set('unsaved-project', this.saveWithNames);
+    // Remove deleted editor from Local Storage.
+    localStorage.removeItem(`unsaved-editor-${this.name}`);
+    localStorage.setItem('unsaved-project', JSON.stringify(this.saveWithNames));
   }
 }
 </script>

--- a/src/components/buttons/RenameEditorButton.vue
+++ b/src/components/buttons/RenameEditorButton.vue
@@ -32,13 +32,13 @@ export default class RenameEditorButton extends Vue {
 
       // Re-save overview to get new node name
       const overviewEditorSave = saveEditor(this.overviewEditor);
-      this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+      localStorage.setItem('unsaved-editor-Overview', JSON.stringify(overviewEditorSave));
 
-      // Replace cookie with updated name
+      // Replace Local Storage with updated name
       const saved: EditorSave = saveEditor(this.getEditor(this.editorType, this.index));
-      this.$cookies.set(`unsaved-editor-${name}`, saved);
-      this.$cookies.set('unsaved-project', this.saveWithNames);
-      this.$cookies.remove(`unsaved-editor-${this.oldName}`);
+      localStorage.setItem(`unsaved-editor-${name}`, JSON.stringify(saved));
+      localStorage.setItem('unsaved-project', JSON.stringify(this.saveWithNames));
+      localStorage.removeItem(`unsaved-editor-${this.oldName}`);
     }
   }
 }

--- a/src/components/navbar/Navbar.vue
+++ b/src/components/navbar/Navbar.vue
@@ -97,8 +97,8 @@ export default class Navbar extends Vue {
 
     const oldEditorSaved: EditorSave = saveEditor(this.currEditorModel);
     const overviewEditorSave: EditorSave = saveEditor(this.overviewEditor);
-    this.$cookies.set(`unsaved-editor-${this.currEditorModel.name}`, oldEditorSaved);
-    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+    localStorage.setItem(`unsaved-editor-${this.currEditorModel.name}`, JSON.stringify(oldEditorSaved));
+    localStorage.setItem('unsaved-editor-Overview', JSON.stringify(overviewEditorSave));
 
     this.switch({ editorType: EditorType.OVERVIEW, index: 0 });
   }

--- a/src/components/navbar/NavbarContextualMenu.vue
+++ b/src/components/navbar/NavbarContextualMenu.vue
@@ -68,8 +68,8 @@ export default class NavbarContextualMenu extends Vue {
 
     const oldEditorSaved: EditorSave = saveEditor(this.currEditorModel);
     const overviewEditorSave: EditorSave = saveEditor(this.overviewEditor);
-    this.$cookies.set(`unsaved-editor-${this.currEditorModel.name}`, oldEditorSaved);
-    this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+    localStorage.setItem(`unsaved-editor-${this.currEditorModel.name}`, JSON.stringify(oldEditorSaved));
+    localStorage.setItem('unsaved-editor-Overview', JSON.stringify(overviewEditorSave));
 
     this.switch({ editorType, index });
   }

--- a/src/components/tabs/FunctionsTab.vue
+++ b/src/components/tabs/FunctionsTab.vue
@@ -139,7 +139,7 @@ export default class FunctionsTab extends Vue {
       } else {
         const file = { filename: files[0].name, functions: parsed, open: false };
         this.addFile(file);
-        this.saveToCookies(file);
+        this.saveToLocalStorage(file);
       }
     };
 
@@ -155,7 +155,7 @@ export default class FunctionsTab extends Vue {
 
     const file = { filename: `${name}.py`, functions: [], open: true };
     this.addFile(file);
-    this.saveToCookies(file);
+    this.saveToLocalStorage(file);
   }
 
   private deleteFile() {
@@ -179,9 +179,9 @@ export default class FunctionsTab extends Vue {
     }
   }
 
-  private saveToCookies(file: ParsedFile) {
-    this.$cookies.set('unsaved-code-vault', this.filenamesList);
-    this.$cookies.set(`unsaved-file-${file.filename}`, file);
+  private saveToLocalStorage(file: ParsedFile) {
+    localStorage.setItem('unsaved-code-vault', JSON.stringify(this.filenamesList));
+    localStorage.setItem(`unsaved-file-${file.filename}`, JSON.stringify(file));
   }
 }
 </script>

--- a/src/components/tabs/IdeTab.vue
+++ b/src/components/tabs/IdeTab.vue
@@ -74,7 +74,7 @@ export default class IdeTab extends Vue {
         // Override file in codevault and save
         const file = { filename: this.filename, functions: newFuncs, open: false };
         this.setFile(file);
-        this.$cookies.set(`unsaved-file-${this.filename}`, file);
+        localStorage.setItem(`unsaved-file-${this.filename}`, JSON.stringify(file));
 
         // Close tab and switch to 'Functions' tab
         this.closeFile(this.filename);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -24,7 +24,7 @@ import { Save, saveEditor, SaveWithNames } from '@/file/EditorAsJson';
 import EditorManager from '@/EditorManager';
 import { EditorModel } from '@/store/editors/types';
 import CodeVault from '@/components/CodeVault.vue';
-import { ParsedFile } from '@/store/codeVault/types';
+import { FilenamesList, ParsedFile } from '@/store/codeVault/types';
 
 @Component({
   components: {
@@ -45,11 +45,11 @@ export default class Home extends Vue {
 
   created() {
     // Auto-loading
-    if (this.$cookies.isKey('unsaved-project')) {
-      const saveWithNames: SaveWithNames = this.$cookies.get('unsaved-project');
-      const overviewEditor = this.$cookies.get('unsaved-editor-Overview');
-      const modelEditors = saveWithNames.modelEditors.map((name) => this.$cookies.get(`unsaved-editor-${name}`));
-      const dataEditors = saveWithNames.dataEditors.map((name) => this.$cookies.get(`unsaved-editor-${name}`));
+    if (localStorage.getItem('unsaved-project')) {
+      const saveWithNames: SaveWithNames = JSON.parse(localStorage.getItem('unsaved-project')!);
+      const overviewEditor = JSON.parse(localStorage.getItem('unsaved-editor-Overview')!);
+      const modelEditors = saveWithNames.modelEditors.map((name) => JSON.parse(localStorage.getItem(`unsaved-editor-${name}`)!));
+      const dataEditors = saveWithNames.dataEditors.map((name) => JSON.parse(localStorage.getItem(`unsaved-editor-${name}`)!));
       this.loadEditors({
         overviewEditor, modelEditors, dataEditors,
       });
@@ -57,9 +57,9 @@ export default class Home extends Vue {
       EditorManager.getInstance().resetView();
 
       // Auto-Load Code Vault
-      if (this.$cookies.isKey('unsaved-code-vault')) {
-        const filenamesList = this.$cookies.get('unsaved-code-vault');
-        const files = filenamesList.filenames.map((filename: string) => this.$cookies.get(`unsaved-file-${filename}`));
+      if (localStorage.getItem('unsaved-code-vault')) {
+        const filenamesList: FilenamesList = JSON.parse(localStorage.getItem('unsaved-code-vault')!);
+        const files = filenamesList.filenames.map((filename: string) => JSON.parse(localStorage.getItem(`unsaved-file-${filename}`)!));
         this.loadFiles(files);
       }
     }
@@ -73,9 +73,9 @@ export default class Home extends Vue {
       const currEditorSave = saveEditor(this.currEditorModel);
       const overviewEditorSave = saveEditor(this.overviewEditor);
 
-      this.$cookies.set('unsaved-project', this.saveWithNames);
-      this.$cookies.set(`unsaved-editor-${this.currEditorModel.name}`, currEditorSave);
-      this.$cookies.set('unsaved-editor-Overview', overviewEditorSave);
+      localStorage.setItem('unsaved-project', JSON.stringify(this.saveWithNames));
+      localStorage.setItem(`unsaved-editor-${this.currEditorModel.name}`, JSON.stringify(currEditorSave));
+      localStorage.setItem('unsaved-editor-Overview', JSON.stringify(overviewEditorSave));
     }, 5000);
   }
 }


### PR DESCRIPTION
Well Matt Green was right, and using _Local Storage_ changes everything! This PR therefore moves all occurrences of saving and loading to and from cookies to use Local Storage instead. 

Additionally, it implements auto-saving the project to Local Storage when loading a file.

Feel free to extensively test it to notice any bug.