### PR TITLE
Add Overview Custom Node with Trainer checkbox

### DIFF
--- a/src/app/parser/ParsedFunction.ts
+++ b/src/app/parser/ParsedFunction.ts
@@ -26,6 +26,10 @@ class ParsedFunction {
 
     return this.name === other.name && this.body === other.body && this.filename === other.filename;
   }
+
+  public containsReturn(): boolean {
+    return this.body.includes('return');
+  }
 }
 
 export default ParsedFunction;

--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -21,6 +21,7 @@
            :initialUp="false"
            v-on:arrow-button-clicked="toggleShouldShowOptions"
            v-show="data.options.size > 0"
+           :blackStroke="data.type === customNode"
          />
       </span>
       <input
@@ -133,6 +134,8 @@ export default class CustomNode extends Components.Node {
   };
 
   private currentErrors: IrError[] = [];
+
+  private customNode = CommonNodes.Custom;
 
   get messages(): string | undefined {
     return this.currentErrors.length !== 0

--- a/src/components/canvas/AbstractCanvas.ts
+++ b/src/components/canvas/AbstractCanvas.ts
@@ -13,6 +13,8 @@ export default abstract class AbstractCanvas {
     }[];
   }[];
 
+  public customNodeType = Custom;
+
   protected option: OptionPlugin = new OptionPlugin();
 
   public get optionPlugin(): OptionPlugin {
@@ -25,6 +27,6 @@ export default abstract class AbstractCanvas {
         editor.registerNodeType(name, node, category);
       });
     });
-    editor.registerNodeType(CommonNodes.Custom, Custom);
+    editor.registerNodeType(CommonNodes.Custom, this.customNodeType);
   }
 }

--- a/src/components/canvas/OverviewCanvas.ts
+++ b/src/components/canvas/OverviewCanvas.ts
@@ -5,6 +5,7 @@ import TrainClassifier from '@/nodes/overview/train/TrainClassifier';
 import Adadelta from '@/nodes/overview/optimizers/Adadelta';
 import { Data } from '@/nodes/overview/Data';
 import { Editor } from '@baklavajs/core';
+import OverviewCustom from '@/nodes/overview/OverviewCustom';
 
 export default class OverviewCanvas extends AbstractCanvas {
   nodeList = [
@@ -27,6 +28,8 @@ export default class OverviewCanvas extends AbstractCanvas {
       ],
     },
   ];
+
+  customNodeType = OverviewCustom;
 
   public registerNodes(editor: Editor) {
     super.registerNodes(editor);

--- a/src/inputs/ArrowButton.vue
+++ b/src/inputs/ArrowButton.vue
@@ -2,14 +2,14 @@
   <div v-on:click="onClick">
     <div v-if="up">
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
-        <line x1="1" y1="8" x2="7" y2="1" fill="none" stroke="#ececec" stroke-width="2"/>
-        <line x1="11.8" y1="8" x2="5.8" y2="1" fill="none" stroke="#ececec" stroke-width="2"/>
+        <line x1="1" y1="8" x2="7" y2="1" fill="none" :stroke="stroke" stroke-width="2"/>
+        <line x1="11.8" y1="8" x2="5.8" y2="1" fill="none" :stroke="stroke" stroke-width="2"/>
       </svg>
     </div>
     <div v-else>
       <svg xmlns="http://www.w3.org/2000/svg" width="14" height="16">
-        <line x1="1" y1="1" x2="7" y2="8" fill="none" stroke="#ececec" stroke-width="2"/>
-        <line x1="11.8" y1="1" x2="5.8" y2="8" fill="none" stroke="#ececec" stroke-width="2"/>
+        <line x1="1" y1="1" x2="7" y2="8" fill="none" :stroke="stroke" stroke-width="2"/>
+        <line x1="11.8" y1="1" x2="5.8" y2="8" fill="none" :stroke="stroke" stroke-width="2"/>
       </svg>
     </div>
   </div>
@@ -21,12 +21,18 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 @Component
 export default class ArrowButton extends Vue {
   @Prop({ default: true }) initialUp!: boolean;
+  @Prop({ default: false }) blackStroke!: boolean;
 
   private up = this.initialUp;
 
   onClick() {
     this.up = !this.up;
     this.$emit('arrow-button-clicked');
+  }
+
+  get stroke() {
+    if (this.blackStroke) return '#131313';
+    return '#ececec';
   }
 }
 </script>

--- a/src/nodes/common/Custom.ts
+++ b/src/nodes/common/Custom.ts
@@ -82,11 +82,11 @@ export default class Custom extends Node {
     this.inputNames = [];
   }
 
-  private addOutput() {
+  public addOutput() {
     this.addOutputInterface('Output');
   }
 
-  private removeOutput() {
+  public removeOutput() {
     if (this.interfaces.has('Output')) {
       this.removeInterface('Output');
     }

--- a/src/nodes/common/Custom.ts
+++ b/src/nodes/common/Custom.ts
@@ -61,7 +61,9 @@ export default class Custom extends Node {
     } else {
       this.name = parsedFunction.name;
       this.setInputs(parsedFunction.args);
-      this.addOutput();
+      if (parsedFunction.containsReturn()) {
+        this.addOutput();
+      }
     }
   }
 

--- a/src/nodes/overview/OverviewCustom.ts
+++ b/src/nodes/overview/OverviewCustom.ts
@@ -1,0 +1,15 @@
+import Custom from '@/nodes/common/Custom';
+import ParsedFunction from '@/app/parser/ParsedFunction';
+import { TypeOptions } from '@/nodes/model/BaklavaDisplayTypeOptions';
+import CheckboxValue from '@/baklava/CheckboxValue';
+
+export enum OverviewCustomOptions {
+  TRAINER = 'Trainer',
+}
+export default class OverviewCustom extends Custom {
+  constructor(parsedFunction?: ParsedFunction) {
+    super(parsedFunction);
+    this.addOption(OverviewCustomOptions.TRAINER,
+      TypeOptions.TickBoxOption, CheckboxValue.UNCHECKED);
+  }
+}

--- a/src/nodes/overview/Types.ts
+++ b/src/nodes/overview/Types.ts
@@ -11,4 +11,5 @@ export enum OverviewNodes {
   DataNode = 'DataNode',
   TrainClassifier = 'TrainClassifier',
   Adadelta = 'Adadelta',
+  Custom = 'Custom',
 }

--- a/src/store/ManageCodevault.ts
+++ b/src/store/ManageCodevault.ts
@@ -9,6 +9,7 @@ export interface FuncDiff {
     oldFunc: ParsedFunction;
     newFunc: ParsedFunction;
     args: { deleted: string[]; added: string[] };
+    returnStatement: { removed: boolean; added: boolean };
   })[];
 }
 
@@ -35,6 +36,7 @@ export function funcsDiff(
     oldFunc: ParsedFunction;
     newFunc: ParsedFunction;
     args: { deleted: string[]; added: string[] };
+    returnStatement: { removed: boolean; added: boolean };
   })[] = [];
 
   oldFuncs.forEach((oldFunc) => {
@@ -53,10 +55,15 @@ export function funcsDiff(
 
       const deletedArgs: string[] = oldFunc.args.filter((arg) => !newFunc.args.includes(arg));
       const addedArgs: string[] = newFunc.args.filter((arg) => !oldFunc.args.includes(arg));
+
+      // Check if return was removed or added
+      const returnRemoved = oldFunc.containsReturn() && !newFunc.containsReturn();
+      const returnAdded = !oldFunc.containsReturn() && newFunc.containsReturn();
       changed.push({
         oldFunc,
         newFunc,
         args: { deleted: deletedArgs, added: addedArgs },
+        returnStatement: { removed: returnRemoved, added: returnAdded },
       });
     }
   });
@@ -91,6 +98,8 @@ export function editNodes(editorModel: EditorModel, diff: FuncDiff) {
         node.setParsedFunction(change.newFunc);
         change.args.added.forEach((arg) => node.addInput(arg));
         change.args.deleted.forEach((arg) => node.remInteface(arg));
+        if (change.returnStatement.added) node.addOutput();
+        if (change.returnStatement.removed) node.removeOutput();
       }
     }
   }


### PR DESCRIPTION
Now, Editors can set their own `customNodeType` parameter (defaults to `Common`) to another Custom Node class. That's now the case with the Overview editor which has an `OverviewCustom` node, with a `Trainer` checkbox.