### PR TITLE
CORE-66 fix no highlighting for selected erroring node

### DIFF
--- a/src/baklava/CustomNode.vue
+++ b/src/baklava/CustomNode.vue
@@ -163,9 +163,13 @@ export default class CustomNode extends Components.Node {
     }
     switch (severities[0]) {
       case Severity.Error:
-        return { 'box-shadow': '0 0 1px 2px var(--red)' };
-      case Severity.Warning: // WARN
-        return { 'box-shadow': '0 0 1px 2px var(--yellow)' };
+        return this.selected
+          ? { 'box-shadow': '0 0 1px 4px var(--red)' }
+          : { 'box-shadow': '0 0 1px 2px var(--red)' };
+      case Severity.Warning:
+        return this.selected
+          ? { 'box-shadow': '0 0 1px 3px var(--yellow)' }
+          : { 'box-shadow': '0 0 1px 1px var(--yellow)' };
       default:
         return {};
     }


### PR DESCRIPTION
Before:
![Screenshot from 2020-11-27 10-54-33](https://user-images.githubusercontent.com/45274424/100441871-082c8200-309f-11eb-834f-a8e026354f3e.png)

After:
![Screenshot from 2020-11-27 10-54-40](https://user-images.githubusercontent.com/45274424/100441888-0e226300-309f-11eb-9357-d1f0c4ce23e2.png)
